### PR TITLE
feat!: パッケージ名を @yuske-nakajima/tileui に変更

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -17,16 +17,14 @@
 
 ## Install
 
-> **Note:** Not yet published to npm. After publishing, install with:
-
 ```bash
-npm install tileui
+npm install @yuske-nakajima/tileui
 ```
 
 ## Quick Start
 
 ```ts
-import TileUI from 'tileui';
+import TileUI from '@yuske-nakajima/tileui';
 
 const params = { speed: 0.5, volume: 80, color: '#ff0000', enabled: true };
 

--- a/README.md
+++ b/README.md
@@ -17,16 +17,14 @@
 
 ## インストール
 
-> **Note:** npm 未公開です。公開後に以下のコマンドでインストールできます。
-
 ```bash
-npm install tileui
+npm install @yuske-nakajima/tileui
 ```
 
 ## クイックスタート
 
 ```ts
-import TileUI from 'tileui';
+import TileUI from '@yuske-nakajima/tileui';
 
 const params = { speed: 0.5, volume: 80, color: '#ff0000', enabled: true };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-	"name": "tileui",
-	"version": "0.1.1",
+	"name": "@yuske-nakajima/tileui",
+	"version": "0.2.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "tileui",
-			"version": "0.1.1",
+			"name": "@yuske-nakajima/tileui",
+			"version": "0.2.0",
 			"license": "MIT",
 			"devDependencies": {
 				"@biomejs/biome": "2.4.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-	"name": "tileui",
-	"version": "0.1.1",
+	"name": "@yuske-nakajima/tileui",
+	"version": "0.2.0",
 	"description": "A grid-tile GUI panel with SVG rotary knobs for creative coding",
 	"type": "module",
 	"main": "./dist/tileui.umd.cjs",


### PR DESCRIPTION
## 概要
- npmレジストリで既存の tile-ui と類似名と判定されたため、scoped パッケージに変更
- 破壊的変更のため 0.2.0 にバージョンアップ

## 変更内容
- package.json: name を `@yuske-nakajima/tileui`、version を `0.2.0` に更新
- README.md / README.en.md: install/import 文を更新、npm 未公開注記を削除

## テスト計画
- [x] `npm run build` 成功
- [x] `npm test` 全27テスト通過
- [x] `npm run check` 通過
- [ ] mainマージ後に auto-tag.yml で v0.2.0 タグ作成 → npm publish 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)