### PR TITLE
docs: READMEにCDNセクションを追加

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -23,6 +23,21 @@
 npm install @yuske-nakajima/tileui
 ```
 
+### CDN
+
+```html
+<!-- UMD -->
+<script src="https://unpkg.com/@yuske-nakajima/tileui"></script>
+<script>
+  const gui = new TileUI();
+</script>
+
+<!-- ESM -->
+<script type="module">
+  import TileUI from 'https://cdn.jsdelivr.net/npm/@yuske-nakajima/tileui/dist/tileui.js';
+</script>
+```
+
 ## Quick Start
 
 ```ts

--- a/README.md
+++ b/README.md
@@ -23,6 +23,21 @@
 npm install @yuske-nakajima/tileui
 ```
 
+### CDN
+
+```html
+<!-- UMD -->
+<script src="https://unpkg.com/@yuske-nakajima/tileui"></script>
+<script>
+  const gui = new TileUI();
+</script>
+
+<!-- ESM -->
+<script type="module">
+  import TileUI from 'https://cdn.jsdelivr.net/npm/@yuske-nakajima/tileui/dist/tileui.js';
+</script>
+```
+
 ## クイックスタート
 
 ```ts


### PR DESCRIPTION
## 概要
- npm公開済みのため、README に CDN セクション（unpkg / jsdelivr）を復活

## 変更内容
- README.md / README.en.md に CDN セクション追加（UMD / ESM）
- CDN URL の導通確認済み

## テスト計画
- [x] unpkg URL でJSが配信されることを確認
- [x] jsdelivr URL でJSが配信されることを確認
- [x] import 文が `@yuske-nakajima/tileui` で統一されていること

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)