### PR TITLE
fix/feat: タイル改善（桁数制限・余白・個別色設定）+ v0.2.1

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -48,6 +48,31 @@
     <code class="install__command" id="install-cmd" title="Click to copy">npm install @yuske-nakajima/tileui</code>
   </section>
 
+  <!-- ショーケース -->
+  <section class="showcase">
+    <h2 class="showcase__title">EXAMPLES</h2>
+
+    <div class="showcase__item">
+      <span class="showcase__label">2 COLUMNS</span>
+      <div id="showcase-2col"></div>
+    </div>
+
+    <div class="showcase__item">
+      <span class="showcase__label">3 COLUMNS</span>
+      <div id="showcase-3col"></div>
+    </div>
+
+    <div class="showcase__item">
+      <span class="showcase__label">4 COLUMNS</span>
+      <div id="showcase-4col"></div>
+    </div>
+
+    <div class="showcase__item">
+      <span class="showcase__label">CUSTOM STYLES</span>
+      <div id="showcase-styled"></div>
+    </div>
+  </section>
+
   <!-- フッター -->
   <footer class="footer">
     <span>KNOB</span>

--- a/demo/main.ts
+++ b/demo/main.ts
@@ -123,12 +123,24 @@ const s5 = new TileUI({
 	columns: 3,
 	title: 'Custom Styles',
 });
-s5.add(sampleParams, 'speed', 0, 100, 1).style({ bgColor: '#2d1b69' });
-s5.add(sampleParams, 'volume', 0, 1, 0.01).style({ bgColor: '#1b4d3e', textColor: '#80ffdb' });
-s5.addColor(sampleParams, 'color').style({ bgColor: '#4a1942' });
-s5.addBoolean(sampleParams, 'enabled').style({ bgColor: '#0d3b66' });
-s5.addButton('Reset', () => {}).style({ bgColor: '#6b2737', textColor: '#ffccd5' });
-s5.addButton('Action', () => {}).style({ bgColor: '#1a472a', textColor: '#90ee90' });
+s5.add(sampleParams, 'speed', 0, 100, 1).style({ bgColor: '#2d1b69', borderColor: '#5b3cc4' });
+s5.add(sampleParams, 'volume', 0, 1, 0.01).style({
+	bgColor: '#1b4d3e',
+	textColor: '#80ffdb',
+	borderColor: '#2d8a6e',
+});
+s5.addColor(sampleParams, 'color').style({ bgColor: '#4a1942', borderColor: '#7a2d6d' });
+s5.addBoolean(sampleParams, 'enabled').style({ bgColor: '#0d3b66', borderColor: '#1a6db5' });
+s5.addButton('Reset', () => {}).style({
+	bgColor: '#6b2737',
+	textColor: '#ffccd5',
+	borderColor: '#a33d52',
+});
+s5.addButton('Action', () => {}).style({
+	bgColor: '#1a472a',
+	textColor: '#90ee90',
+	borderColor: '#2d8a4e',
+});
 
 // インストールコマンドのクリックコピー
 const installCmd = document.getElementById('install-cmd');

--- a/demo/main.ts
+++ b/demo/main.ts
@@ -12,6 +12,7 @@ window.addEventListener('resize', resizeSketch);
 // tileui パネルを #gui コンテナに生成
 const gui = new TileUI({
 	container: document.getElementById('gui')!,
+	columns: 2,
 	title: 'Controls',
 });
 
@@ -78,6 +79,56 @@ gui.addButton('Reset', () => {
 	Object.assign(artParams, defaults);
 	gui.updateDisplay();
 });
+
+// === ショーケース ===
+
+const sampleParams = { speed: 50, volume: 0.8, color: '#ff6600', enabled: true };
+
+function addSampleControls(g: TileUI) {
+	g.add(sampleParams, 'speed', 0, 100, 1);
+	g.add(sampleParams, 'volume', 0, 1, 0.01);
+	g.addColor(sampleParams, 'color');
+	g.addBoolean(sampleParams, 'enabled');
+	g.addButton('Reset', () => {});
+	g.addButton('Action', () => {});
+}
+
+// 2列
+const s2 = new TileUI({
+	container: document.getElementById('showcase-2col')!,
+	columns: 2,
+	title: '2 Columns',
+});
+addSampleControls(s2);
+
+// 3列
+const s3 = new TileUI({
+	container: document.getElementById('showcase-3col')!,
+	columns: 3,
+	title: '3 Columns',
+});
+addSampleControls(s3);
+
+// 4列
+const s4 = new TileUI({
+	container: document.getElementById('showcase-4col')!,
+	columns: 4,
+	title: '4 Columns',
+});
+addSampleControls(s4);
+
+// 個別スタイル
+const s5 = new TileUI({
+	container: document.getElementById('showcase-styled')!,
+	columns: 3,
+	title: 'Custom Styles',
+});
+s5.add(sampleParams, 'speed', 0, 100, 1).style({ bgColor: '#2d1b69' });
+s5.add(sampleParams, 'volume', 0, 1, 0.01).style({ bgColor: '#1b4d3e', textColor: '#80ffdb' });
+s5.addColor(sampleParams, 'color').style({ bgColor: '#4a1942' });
+s5.addBoolean(sampleParams, 'enabled').style({ bgColor: '#0d3b66' });
+s5.addButton('Reset', () => {}).style({ bgColor: '#6b2737', textColor: '#ffccd5' });
+s5.addButton('Action', () => {}).style({ bgColor: '#1a472a', textColor: '#90ee90' });
 
 // インストールコマンドのクリックコピー
 const installCmd = document.getElementById('install-cmd');

--- a/demo/style.css
+++ b/demo/style.css
@@ -48,6 +48,7 @@ body {
 .main,
 .tagline,
 .install,
+.showcase,
 .footer {
 	max-width: 1200px;
 	margin-inline: auto;
@@ -150,6 +151,35 @@ body {
 
 .install__command:hover {
 	opacity: 0.8;
+}
+
+/* ショーケース — Nothing design */
+.showcase {
+	padding-bottom: clamp(40px, 8vw, 64px);
+}
+
+.showcase__title {
+	font-family: "Space Mono", monospace;
+	font-size: 12px;
+	font-weight: 400;
+	text-transform: uppercase;
+	letter-spacing: 0.2em;
+	color: #888888;
+	margin-bottom: clamp(32px, 6vw, 48px);
+}
+
+.showcase__item {
+	margin-bottom: clamp(32px, 6vw, 48px);
+}
+
+.showcase__label {
+	display: block;
+	font-family: "Space Mono", monospace;
+	font-size: 11px;
+	text-transform: uppercase;
+	letter-spacing: 0.15em;
+	color: #555555;
+	margin-bottom: 12px;
 }
 
 /* フッター — fluid spacing */

--- a/demo/tsconfig.json
+++ b/demo/tsconfig.json
@@ -1,0 +1,16 @@
+{
+	"compilerOptions": {
+		"target": "ES2020",
+		"module": "ESNext",
+		"moduleResolution": "bundler",
+		"lib": ["ES2020", "DOM", "DOM.Iterable"],
+		"strict": true,
+		"esModuleInterop": true,
+		"skipLibCheck": true,
+		"forceConsistentCasingInFileNames": true,
+		"isolatedModules": true,
+		"noEmit": true,
+		"types": []
+	},
+	"include": ["./**/*.ts", "../src/**/*.ts"]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@yuske-nakajima/tileui",
-	"version": "0.2.0",
+	"version": "0.2.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@yuske-nakajima/tileui",
-			"version": "0.2.0",
+			"version": "0.2.1",
 			"license": "MIT",
 			"devDependencies": {
 				"@biomejs/biome": "2.4.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@yuske-nakajima/tileui",
-	"version": "0.2.0",
+	"version": "0.2.1",
 	"description": "A grid-tile GUI panel with SVG rotary knobs for creative coding",
 	"type": "module",
 	"main": "./dist/tileui.umd.cjs",

--- a/src/__tests__/TileUI.test.ts
+++ b/src/__tests__/TileUI.test.ts
@@ -165,6 +165,67 @@ describe('TileUI', () => {
 		});
 	});
 
+	describe('style()', () => {
+		it('bgColor を指定するとタイルの backgroundColor が変更される', () => {
+			const gui = new TileUI({ container });
+			const params = { speed: 50 };
+			const ctrl = gui.add(params, 'speed', 0, 100);
+			ctrl.style({ bgColor: '#ff0000' });
+			const tile = container.querySelector(`.${CSS_PREFIX}-tile-knob`) as HTMLElement;
+			expect(tile.style.backgroundColor).toBe('rgb(255, 0, 0)');
+			gui.dispose();
+		});
+
+		it('textColor を指定するとタイルの color が変更される', () => {
+			const gui = new TileUI({ container });
+			const params = { speed: 50 };
+			const ctrl = gui.add(params, 'speed', 0, 100);
+			ctrl.style({ textColor: '#ffffff' });
+			const tile = container.querySelector(`.${CSS_PREFIX}-tile-knob`) as HTMLElement;
+			expect(tile.style.color).toBe('rgb(255, 255, 255)');
+			gui.dispose();
+		});
+
+		it('bgColor と textColor を同時に指定できる', () => {
+			const gui = new TileUI({ container });
+			const params = { speed: 50 };
+			const ctrl = gui.add(params, 'speed', 0, 100);
+			ctrl.style({ bgColor: '#ff0000', textColor: '#ffffff' });
+			const tile = container.querySelector(`.${CSS_PREFIX}-tile-knob`) as HTMLElement;
+			expect(tile.style.backgroundColor).toBe('rgb(255, 0, 0)');
+			expect(tile.style.color).toBe('rgb(255, 255, 255)');
+			gui.dispose();
+		});
+
+		it('onChange と style をチェーンで呼び出せる', () => {
+			const gui = new TileUI({ container });
+			const params = { speed: 50 };
+			const callback = vi.fn();
+			const ctrl = gui.add(params, 'speed', 0, 100);
+			// onChange → style のチェーン
+			const result = ctrl.onChange(callback).style({ bgColor: '#00ff00' });
+			expect(result).toBe(ctrl);
+			const tile = container.querySelector(`.${CSS_PREFIX}-tile-knob`) as HTMLElement;
+			expect(tile.style.backgroundColor).toBe('rgb(0, 255, 0)');
+			// コールバックも正常動作
+			ctrl.value = 75;
+			expect(callback).toHaveBeenCalledWith(75);
+			gui.dispose();
+		});
+
+		it('style → onChange のチェーンも動作する', () => {
+			const gui = new TileUI({ container });
+			const params = { speed: 50 };
+			const callback = vi.fn();
+			const ctrl = gui.add(params, 'speed', 0, 100);
+			const result = ctrl.style({ textColor: '#000000' }).onChange(callback);
+			expect(result).toBe(ctrl);
+			ctrl.value = 25;
+			expect(callback).toHaveBeenCalledWith(25);
+			gui.dispose();
+		});
+	});
+
 	describe('columns オプション', () => {
 		it('columns を指定するとグリッド列数が固定される', () => {
 			const gui = new TileUI({ container, columns: 3 });

--- a/src/__tests__/TileUI.test.ts
+++ b/src/__tests__/TileUI.test.ts
@@ -224,6 +224,16 @@ describe('TileUI', () => {
 			expect(callback).toHaveBeenCalledWith(25);
 			gui.dispose();
 		});
+
+		it('borderColor を指定するとタイルの borderColor が変更される', () => {
+			const gui = new TileUI({ container });
+			const params = { speed: 50 };
+			const ctrl = gui.add(params, 'speed', 0, 100);
+			ctrl.style({ borderColor: '#ff0000' });
+			const tile = container.querySelector(`.${CSS_PREFIX}-tile-knob`) as HTMLElement;
+			expect(tile.style.borderColor).toBe('rgb(255, 0, 0)');
+			gui.dispose();
+		});
 	});
 
 	describe('columns オプション', () => {

--- a/src/controllers/Controller.ts
+++ b/src/controllers/Controller.ts
@@ -41,6 +41,22 @@ export abstract class Controller<T = unknown> {
 		return this;
 	}
 
+	/**
+	 * タイルの背景色・フォントカラーを設定する
+	 * @returns メソッドチェーン用に this を返す
+	 */
+	style(options: { bgColor?: string; textColor?: string }): this {
+		if (this.element) {
+			if (options.bgColor) {
+				this.element.style.backgroundColor = options.bgColor;
+			}
+			if (options.textColor) {
+				this.element.style.color = options.textColor;
+			}
+		}
+		return this;
+	}
+
 	/** DOM の表示を現在の値に同期する */
 	updateDisplay(): void {
 		// サブクラスでオーバーライドして表示を更新する

--- a/src/controllers/Controller.ts
+++ b/src/controllers/Controller.ts
@@ -45,13 +45,16 @@ export abstract class Controller<T = unknown> {
 	 * タイルの背景色・フォントカラーを設定する
 	 * @returns メソッドチェーン用に this を返す
 	 */
-	style(options: { bgColor?: string; textColor?: string }): this {
+	style(options: { bgColor?: string; textColor?: string; borderColor?: string }): this {
 		if (this.element) {
 			if (options.bgColor) {
 				this.element.style.backgroundColor = options.bgColor;
 			}
 			if (options.textColor) {
 				this.element.style.color = options.textColor;
+			}
+			if (options.borderColor) {
+				this.element.style.borderColor = options.borderColor;
 			}
 		}
 		return this;

--- a/src/controllers/KnobController.ts
+++ b/src/controllers/KnobController.ts
@@ -9,6 +9,7 @@ import {
 	KNOB_TRACK_WIDTH,
 	KNOB_VALUE_WIDTH,
 } from '../constants';
+import { formatValue } from '../utils/number';
 import { describeArc, polarToCartesian } from '../utils/svg';
 import { Controller } from './Controller';
 
@@ -164,9 +165,9 @@ export class KnobController extends Controller<number> {
 			this.thumb.setAttribute('cy', String(pos.y));
 		}
 
-		// 値テキストの更新
+		// 値テキストの更新（step に応じた桁数で表示）
 		if (this.valueSpan) {
-			this.valueSpan.textContent = String(this.value);
+			this.valueSpan.textContent = formatValue(this.value, this.step);
 		}
 	}
 

--- a/src/styles/inject.ts
+++ b/src/styles/inject.ts
@@ -5,7 +5,7 @@ const TILEUI_CSS = `
 /* TileUI CSS 変数（テーマカスタマイズ用） */
 :root {
 	--tileui-tile-size: 100px;
-	--tileui-gap: 2px;
+	--tileui-gap: 0px;
 	--tileui-bg: #1a1a2e;
 	--tileui-tile-bg: #16213e;
 	--tileui-tile-bg-hover: #1c2a4a;

--- a/src/styles/inject.ts
+++ b/src/styles/inject.ts
@@ -26,7 +26,7 @@ const TILEUI_CSS = `
 
 /* パネルコンテナ（CSS Grid） */
 .tileui-panel {
-	display: grid;
+	display: inline-grid;
 	grid-template-columns: repeat(auto-fill, var(--tileui-tile-size));
 	gap: var(--tileui-gap);
 	padding: var(--tileui-gap);

--- a/src/styles/inject.ts
+++ b/src/styles/inject.ts
@@ -45,7 +45,7 @@ const TILEUI_CSS = `
 	height: var(--tileui-tile-size);
 	background: var(--tileui-tile-bg);
 	border: 1px solid var(--tileui-border);
-	border-radius: var(--tileui-radius);
+	margin: -0.5px;
 	display: flex;
 	flex-direction: column;
 	align-items: center;

--- a/src/utils/number.ts
+++ b/src/utils/number.ts
@@ -1,0 +1,29 @@
+/**
+ * step の小数点以下の桁数を返す
+ * @param step - ステップ値（例: 0.01 → 2, 1 → 0, 0.1 → 1）
+ * @returns 小数点以下の桁数
+ */
+export function getDecimalPlaces(step: number): number {
+	const parts = step.toString().split('.');
+	return parts[1]?.length ?? 0;
+}
+
+/** step 未指定時のデフォルト小数桁数 */
+const DEFAULT_MAX_DECIMALS = 2;
+
+/**
+ * 値を step に応じた小数桁数でフォーマットする
+ * step が未指定（デフォルト値）の場合は最大2桁に制限する
+ * @param value - フォーマット対象の値
+ * @param step - ステップ値（undefined の場合はデフォルト桁数を使用）
+ * @returns フォーマット済みの文字列
+ */
+export function formatValue(value: number, step?: number): string {
+	if (step === undefined) {
+		// step 未指定の場合はデフォルトで小数点以下2桁を上限とする
+		const decimals = Math.min(getDecimalPlaces(value), DEFAULT_MAX_DECIMALS);
+		return value.toFixed(decimals);
+	}
+	const decimals = getDecimalPlaces(step);
+	return value.toFixed(decimals);
+}


### PR DESCRIPTION
## 概要
- ノブの値表示の小数点桁数制限、タイル間余白の解消、個別色設定APIの追加
- デモページにショーケースセクション追加
- v0.2.1 リリース

## 変更内容
- fix: ノブの値表示でstepに応じた小数点桁数制限（formatValueユーティリティ追加）
- fix: タイル間の余白解消（--tileui-gap: 0px、border重ね、inline-grid）
- feat: .style({ bgColor, textColor, borderColor }) チェーンAPI追加
- feat(demo): ショーケースセクション（2/3/4列 + Custom Styles）
- fix: demo用tsconfig.jsonでTS6059エラー解消

## テスト計画
- [x] npm test: 33テスト全通過（+6件追加）
- [x] npm run build 成功
- [x] npm run build:demo 成功
- [x] npm run check 通過

Closes #26 Closes #27 Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)