### PR TITLE
fix: デモページのバージョン表示を自動注入に変更

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -26,7 +26,7 @@
   <header class="header">
     <span class="header__logo">TILEUI</span>
     <nav class="header__nav">
-      <span class="header__version">v0.2.0</span>
+      <span class="header__version" id="version"></span>
       <a class="header__link" href="https://www.npmjs.com/package/@yuske-nakajima/tileui" target="_blank" rel="noopener noreferrer">npm</a>
       <a class="header__link" href="https://github.com/yuske-nakajima/tileui" target="_blank" rel="noopener noreferrer">GitHub &#8599;</a>
     </nav>

--- a/demo/main.ts
+++ b/demo/main.ts
@@ -1,7 +1,12 @@
 // TileUI デモ — パネル + p5.js ジェネラティブアート連携
 
+declare const __VERSION__: string;
+
 import TileUI from '../src';
 import { artParams, initSketch, resizeSketch } from './sketch';
+
+// バージョン表示（package.json から自動注入）
+document.getElementById('version')!.textContent = `v${__VERSION__}`;
 
 // p5.js スケッチを初期化
 initSketch(document.getElementById('sketch')!);

--- a/vite.config.demo.ts
+++ b/vite.config.demo.ts
@@ -1,8 +1,15 @@
+import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { defineConfig } from 'vite';
 
+// package.json から version を読み取り
+const pkg = JSON.parse(readFileSync(resolve(import.meta.dirname, 'package.json'), 'utf-8'));
+
 // デモページ専用のビルド設定
 export default defineConfig({
+	define: {
+		__VERSION__: JSON.stringify(pkg.version),
+	},
 	root: resolve(import.meta.dirname, 'demo'),
 	base: '/',
 	build: {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,10 +1,17 @@
+import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { defineConfig } from 'vite';
+
+// package.json から version を読み取り
+const pkg = JSON.parse(readFileSync(resolve(import.meta.dirname, 'package.json'), 'utf-8'));
 
 // Vite 8.x では import.meta.dirname を使用
 export default defineConfig(({ command }) => ({
 	// dev server はデモページをルートにする
 	root: command === 'serve' ? resolve(import.meta.dirname, 'demo') : undefined,
+	define: {
+		__VERSION__: JSON.stringify(pkg.version),
+	},
 	build: {
 		rollupOptions: {
 			output: {


### PR DESCRIPTION
## 概要
- デモページのバージョン表示をハードコードからpackage.json自動注入に変更

## 変更内容
- vite.config.ts / vite.config.demo.ts: `define: { __VERSION__ }` で version を注入
- demo/index.html: ハードコード `v0.2.0` を削除
- demo/main.ts: `__VERSION__` から動的に表示

## テスト計画
- [x] npm test: 33テスト全通過
- [x] npm run build 成功
- [x] npm run build:demo 成功（ビルド出力に v0.2.1 が含まれることを確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)