### PR TITLE
style(demo): デモページのスタイル統一と改善

### DIFF
--- a/demo/style.css
+++ b/demo/style.css
@@ -2,7 +2,7 @@
 
 /* tileui CSS 変数のモノクロオーバーライド */
 :root {
-	--tileui-bg: #111111;
+	--tileui-bg: #000000;
 	--tileui-tile-bg: #1a1a1a;
 	--tileui-tile-bg-hover: #222222;
 	--tileui-border: #333333;
@@ -113,9 +113,12 @@ body {
 	overflow: hidden;
 }
 
-/* GUI パネルエリア */
+/* GUI パネルエリア — 白系の細い border でコミカルに */
 .gui-area {
 	min-width: 280px;
+	border: 1px solid rgba(250, 249, 246, 0.15);
+	border-radius: 8px;
+	padding: 4px;
 }
 
 /* タグライン — fluid typography & spacing */

--- a/demo/style.css
+++ b/demo/style.css
@@ -175,6 +175,13 @@ body {
 	margin-bottom: clamp(32px, 6vw, 48px);
 }
 
+/* ショーケース内のパネルにも gui-area と同じ枠を適用 */
+.showcase__item .tileui-panel {
+	border: 1px solid rgba(250, 249, 246, 0.15);
+	border-radius: 8px;
+	padding: 4px;
+}
+
 .showcase__label {
 	display: block;
 	font-family: "Space Mono", monospace;

--- a/demo/style.css
+++ b/demo/style.css
@@ -1,7 +1,11 @@
 /* === tileui デモページ — Nothing design スタイル === */
 
-/* tileui CSS 変数のモノクロオーバーライド（!important でライブラリ注入より優先） */
-:root {
+/*
+ * tileui CSS 変数のモノクロオーバーライド
+ * ライブラリの injectStyles() が :root に後から注入するため、
+ * .tileui-panel スコープで上書きして確実に適用する
+ */
+.tileui-panel {
 	--tileui-bg: #000000;
 	--tileui-tile-bg: #000000;
 	--tileui-tile-bg-hover: #111111;

--- a/demo/style.css
+++ b/demo/style.css
@@ -113,6 +113,11 @@ body {
 	overflow: hidden;
 }
 
+/* パネルのタイトル背景もページと統一 */
+.tileui-title {
+	background: transparent;
+}
+
 /* GUI パネルエリア — 白系の細い border でコミカルに */
 .gui-area {
 	border: 1px solid rgba(250, 249, 246, 0.15);

--- a/demo/style.css
+++ b/demo/style.css
@@ -180,11 +180,12 @@ body {
 	margin-bottom: clamp(32px, 6vw, 48px);
 }
 
-/* ショーケース内のパネルにも gui-area と同じ枠を適用 */
-.showcase__item .tileui-panel {
+/* ショーケース内のパネルラッパーに gui-area と同じ枠を適用 */
+.showcase__item > div {
 	border: 1px solid rgba(250, 249, 246, 0.15);
 	border-radius: 8px;
 	padding: 4px;
+	width: fit-content;
 }
 
 .showcase__label {

--- a/demo/style.css
+++ b/demo/style.css
@@ -1,6 +1,6 @@
 /* === tileui デモページ — Nothing design スタイル === */
 
-/* tileui CSS 変数のモノクロオーバーライド */
+/* tileui CSS 変数のモノクロオーバーライド（!important でライブラリ注入より優先） */
 :root {
 	--tileui-bg: #000000;
 	--tileui-tile-bg: #000000;

--- a/demo/style.css
+++ b/demo/style.css
@@ -3,8 +3,8 @@
 /* tileui CSS 変数のモノクロオーバーライド */
 :root {
 	--tileui-bg: #000000;
-	--tileui-tile-bg: #1a1a1a;
-	--tileui-tile-bg-hover: #222222;
+	--tileui-tile-bg: #000000;
+	--tileui-tile-bg-hover: #111111;
 	--tileui-border: #333333;
 	--tileui-text: #faf9f6;
 	--tileui-text-muted: #888888;

--- a/demo/style.css
+++ b/demo/style.css
@@ -106,8 +106,7 @@ body {
 /* キャンバスエリア — overflow: hidden で p5.js キャンバスのはみ出しを防止 */
 .canvas-area {
 	aspect-ratio: 1 / 1;
-	background: #111111;
-	border-radius: 4px;
+	background: #000000;
 	max-width: 600px;
 	width: 100%;
 	overflow: hidden;

--- a/demo/style.css
+++ b/demo/style.css
@@ -115,10 +115,10 @@ body {
 
 /* GUI パネルエリア — 白系の細い border でコミカルに */
 .gui-area {
-	min-width: 280px;
 	border: 1px solid rgba(250, 249, 246, 0.15);
 	border-radius: 8px;
 	padding: 4px;
+	width: fit-content;
 }
 
 /* タグライン — fluid typography & spacing */


### PR DESCRIPTION
## 概要
- デモページ全体の背景色を統一（パネル・タイル・キャンバスすべて #000000）
- tileui パネルに白系の細い border を追加してコミカルな見た目に
- CSS 変数オーバーライドを .tileui-panel スコープで確実に適用

## 変更内容
- gui-area / ショーケースに border + border-radius + padding を追加
- --tileui-bg / --tileui-tile-bg を #000000 に統一
- CSS 変数オーバーライドを :root → .tileui-panel スコープに変更（injectStyles() 後勝ち対策）
- gui-area を width: fit-content でタイルにフィット
- キャンバスエリアの背景色をページと統一

## テスト計画
- [x] npm run build:demo 成功
- [x] 目視確認：デスクトップ / モバイル

🤖 Generated with [Claude Code](https://claude.com/claude-code)