### PR TITLE
chore: ビルド出力の最適化（minify有効化、コメント削除）

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
 		"dev:bg": "vite > /dev/null 2>&1 & echo $! > .vite.pid && echo 'Vite started (PID:'$(cat .vite.pid)')'",
 		"dev:status": "if [ -f .vite.pid ] && kill -0 $(cat .vite.pid) 2>/dev/null; then echo \"Running (PID: $(cat .vite.pid))\"; curl -s http://localhost:5173 > /dev/null && echo 'http://localhost:5173' || echo 'Starting...'; else echo 'Not running'; fi",
 		"dev:stop": "if [ -f .vite.pid ] && kill -0 $(cat .vite.pid) 2>/dev/null; then kill $(cat .vite.pid) && rm -f .vite.pid && echo 'Stopped'; else echo 'Not running'; rm -f .vite.pid; fi",
-		"build": "vite build && tsc --emitDeclarationOnly",
+		"build": "vite build && node -e \"const fs=require('fs');['dist/tileui.js','dist/tileui.umd.cjs'].forEach(f=>{fs.writeFileSync(f,fs.readFileSync(f,'utf8').replace(/\\/\\/#region[^\\n]*\\n/g,'').replace(/\\/\\/#endregion[^\\n]*\\n?/g,''))})\" && tsc --emitDeclarationOnly",
 		"build:demo": "vite build --config vite.config.demo.ts",
 		"check": "biome check . && eslint .",
 		"format": "biome format --write .",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -13,6 +13,7 @@ export default defineConfig(({ command }) => ({
 		__VERSION__: JSON.stringify(pkg.version),
 	},
 	build: {
+		minify: 'oxc',
 		rollupOptions: {
 			output: {
 				exports: 'named',


### PR DESCRIPTION
## 概要
- ライブラリビルド出力からコメントを削除し、minify を有効化

## 変更内容
- vite.config.ts: `minify: 'oxc'` を追加
- build スクリプト: ビルド後に `//#region` コメントを自動削除
- ES format の空白は Vite lib mode の仕様で保持（tree-shaking 対応）

## テスト計画
- [x] npm test: 34テスト全通過
- [x] npm run build 成功
- [x] ビルド出力にコメントが含まれないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)