### PR TITLE
chore: eslint 10.2.0 へ更新し lint 警告を修正

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -25,6 +25,15 @@
 		}
 	},
 	"files": {
-		"includes": ["**", "!dist", "!demo-dist", "!node_modules", "!.claude", "!.vite"]
+		"includes": [
+			"**",
+			"!dist",
+			"!demo-dist",
+			"!node_modules",
+			"!.claude",
+			"!.vite",
+			"!test-results",
+			"!playwright-report"
+		]
 	}
 }

--- a/demo/main.ts
+++ b/demo/main.ts
@@ -5,18 +5,27 @@ declare const __VERSION__: string;
 import TileUI from '../src';
 import { artParams, initSketch, resizeSketch } from './sketch';
 
+/** ID から要素を取得し、見つからなければエラーを投げる */
+function getElement(id: string): HTMLElement {
+	const el = document.getElementById(id);
+	if (!el) {
+		throw new Error(`要素 #${id} が見つかりません`);
+	}
+	return el;
+}
+
 // バージョン表示（package.json から自動注入）
-document.getElementById('version')!.textContent = `v${__VERSION__}`;
+getElement('version').textContent = `v${__VERSION__}`;
 
 // p5.js スケッチを初期化
-initSketch(document.getElementById('sketch')!);
+initSketch(getElement('sketch'));
 
 // ウィンドウリサイズ時にキャンバスサイズを追従
 window.addEventListener('resize', resizeSketch);
 
 // tileui パネルを #gui コンテナに生成
 const gui = new TileUI({
-	container: document.getElementById('gui')!,
+	container: getElement('gui'),
 	title: 'Controls',
 });
 
@@ -137,7 +146,7 @@ function addSampleControls(g: TileUI, ac: string) {
 
 // 2列
 const s2 = new TileUI({
-	container: document.getElementById('showcase-2col')!,
+	container: getElement('showcase-2col'),
 	columns: 2,
 	title: '2 Columns',
 });
@@ -145,7 +154,7 @@ addSampleControls(s2, showcaseAccents.col2);
 
 // 3列
 const s3 = new TileUI({
-	container: document.getElementById('showcase-3col')!,
+	container: getElement('showcase-3col'),
 	columns: 3,
 	title: '3 Columns',
 });
@@ -153,7 +162,7 @@ addSampleControls(s3, showcaseAccents.col3);
 
 // 4列
 const s4 = new TileUI({
-	container: document.getElementById('showcase-4col')!,
+	container: getElement('showcase-4col'),
 	columns: 4,
 	title: '4 Columns',
 });
@@ -161,7 +170,7 @@ addSampleControls(s4, showcaseAccents.col4);
 
 // 個別スタイル
 const s5 = new TileUI({
-	container: document.getElementById('showcase-styled')!,
+	container: getElement('showcase-styled'),
 	columns: 3,
 	title: 'Custom Styles',
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
 	"name": "@yuske-nakajima/tileui",
-	"version": "0.2.3",
+	"version": "0.2.4",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@yuske-nakajima/tileui",
-			"version": "0.2.3",
+			"version": "0.2.4",
 			"license": "MIT",
 			"devDependencies": {
 				"@biomejs/biome": "2.4.10",
 				"@playwright/test": "1.59.1",
-				"eslint": "10.1.0",
+				"eslint": "10.2.0",
 				"jsdom": "29.0.1",
 				"terser": "5.46.1",
 				"typescript": "6.0.2",
@@ -454,13 +454,13 @@
 			}
 		},
 		"node_modules/@eslint/config-array": {
-			"version": "0.23.3",
-			"resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.3.tgz",
-			"integrity": "sha512-j+eEWmB6YYLwcNOdlwQ6L2OsptI/LO6lNBuLIqe5R7RetD658HLoF+Mn7LzYmAWWNNzdC6cqP+L6r8ujeYXWLw==",
+			"version": "0.23.5",
+			"resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.5.tgz",
+			"integrity": "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@eslint/object-schema": "^3.0.3",
+				"@eslint/object-schema": "^3.0.5",
 				"debug": "^4.3.1",
 				"minimatch": "^10.2.4"
 			},
@@ -469,22 +469,22 @@
 			}
 		},
 		"node_modules/@eslint/config-helpers": {
-			"version": "0.5.3",
-			"resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.3.tgz",
-			"integrity": "sha512-lzGN0onllOZCGroKJmRwY6QcEHxbjBw1gwB8SgRSqK8YbbtEXMvKynsXc3553ckIEBxsbMBU7oOZXKIPGZNeZw==",
+			"version": "0.5.5",
+			"resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.5.tgz",
+			"integrity": "sha512-eIJYKTCECbP/nsKaaruF6LW967mtbQbsw4JTtSVkUQc9MneSkbrgPJAbKl9nWr0ZeowV8BfsarBmPpBzGelA2w==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@eslint/core": "^1.1.1"
+				"@eslint/core": "^1.2.1"
 			},
 			"engines": {
 				"node": "^20.19.0 || ^22.13.0 || >=24"
 			}
 		},
 		"node_modules/@eslint/core": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.1.1.tgz",
-			"integrity": "sha512-QUPblTtE51/7/Zhfv8BDwO0qkkzQL7P/aWWbqcf4xWLEYn1oKjdO0gglQBB4GAsu7u6wjijbCmzsUTy6mnk6oQ==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.1.tgz",
+			"integrity": "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -495,9 +495,9 @@
 			}
 		},
 		"node_modules/@eslint/object-schema": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.3.tgz",
-			"integrity": "sha512-iM869Pugn9Nsxbh/YHRqYiqd23AmIbxJOcpUMOuWCVNdoQJ5ZtwL6h3t0bcZzJUlC3Dq9jCFCESBZnX0GTv7iQ==",
+			"version": "3.0.5",
+			"resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.5.tgz",
+			"integrity": "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"engines": {
@@ -505,13 +505,13 @@
 			}
 		},
 		"node_modules/@eslint/plugin-kit": {
-			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.6.1.tgz",
-			"integrity": "sha512-iH1B076HoAshH1mLpHMgwdGeTs0CYwL0SPMkGuSebZrwBp16v415e9NZXg2jtrqPVQjf6IANe2Vtlr5KswtcZQ==",
+			"version": "0.7.1",
+			"resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.1.tgz",
+			"integrity": "sha512-rZAP3aVgB9ds9KOeUSL+zZ21hPmo8dh6fnIFwRQj5EAZl9gzR7wxYbYXYysAM8CTqGmUGyp2S4kUdV17MnGuWQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@eslint/core": "^1.1.1",
+				"@eslint/core": "^1.2.1",
 				"levn": "^0.4.1"
 			},
 			"engines": {
@@ -1580,18 +1580,18 @@
 			}
 		},
 		"node_modules/eslint": {
-			"version": "10.1.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-10.1.0.tgz",
-			"integrity": "sha512-S9jlY/ELKEUwwQnqWDO+f+m6sercqOPSqXM5Go94l7DOmxHVDgmSFGWEzeE/gwgTAr0W103BWt0QLe/7mabIvA==",
+			"version": "10.2.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-10.2.0.tgz",
+			"integrity": "sha512-+L0vBFYGIpSNIt/KWTpFonPrqYvgKw1eUI5Vn7mEogrQcWtWYtNQ7dNqC+px/J0idT3BAkiWrhfS7k+Tum8TUA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.8.0",
 				"@eslint-community/regexpp": "^4.12.2",
-				"@eslint/config-array": "^0.23.3",
-				"@eslint/config-helpers": "^0.5.3",
-				"@eslint/core": "^1.1.1",
-				"@eslint/plugin-kit": "^0.6.1",
+				"@eslint/config-array": "^0.23.4",
+				"@eslint/config-helpers": "^0.5.4",
+				"@eslint/core": "^1.2.0",
+				"@eslint/plugin-kit": "^0.7.0",
 				"@humanfs/node": "^0.16.6",
 				"@humanwhocodes/module-importer": "^1.0.1",
 				"@humanwhocodes/retry": "^0.4.2",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
 	"devDependencies": {
 		"@biomejs/biome": "2.4.10",
 		"@playwright/test": "1.59.1",
-		"eslint": "10.1.0",
+		"eslint": "10.2.0",
 		"jsdom": "29.0.1",
 		"terser": "5.46.1",
 		"typescript": "6.0.2",


### PR DESCRIPTION
## 概要
- eslint のマイナーアップデートと、既存の lint 警告を修正

## 変更内容
- eslint 10.1.0 → 10.2.0（devDependency）
- biome の除外対象に test-results, playwright-report を追加
- demo/main.ts の non-null assertion を getElement ヘルパーに置換

## テスト計画
- npm run check がエラーなしで通ること
- npm test が全件パスすること

Closes #45