### PR TITLE
chore: jsdom 29.0.2, vitest 4.1.3 へパッチアップデート

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -34,7 +34,8 @@
 			"!.vite",
 			"!test-results",
 			"!playwright-report",
-			"!.vscode"
+			"!.vscode",
+			"!dock-eval-playwright.ts"
 		]
 	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,54 +1,52 @@
 {
 	"name": "@yuske-nakajima/tileui",
-	"version": "0.2.4",
+	"version": "0.2.5",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@yuske-nakajima/tileui",
-			"version": "0.2.4",
+			"version": "0.2.5",
 			"license": "MIT",
 			"devDependencies": {
 				"@biomejs/biome": "2.4.10",
 				"@playwright/test": "1.59.1",
 				"eslint": "10.2.0",
-				"jsdom": "29.0.1",
+				"jsdom": "29.0.2",
 				"terser": "5.46.1",
 				"typescript": "6.0.2",
 				"typescript-eslint": "8.58.0",
 				"vite": "8.0.7",
-				"vitest": "4.1.2"
+				"vitest": "4.1.3"
 			}
 		},
 		"node_modules/@asamuzakjp/css-color": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.1.tgz",
-			"integrity": "sha512-iGWN8E45Ws0XWx3D44Q1t6vX2LqhCKcwfmwBYCDsFrYFS6m4q/Ks61L2veETaLv+ckDC6+dTETJoaAAb7VjLiw==",
+			"version": "5.1.10",
+			"resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.10.tgz",
+			"integrity": "sha512-02OhhkKtgNRuicQ/nF3TRnGsxL9wp0r3Y7VlKWyOHHGmGyvXv03y+PnymU8FKFJMTjIr1Bk8U2g1HWSLrpAHww==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@csstools/css-calc": "^3.1.1",
 				"@csstools/css-color-parser": "^4.0.2",
 				"@csstools/css-parser-algorithms": "^4.0.0",
-				"@csstools/css-tokenizer": "^4.0.0",
-				"lru-cache": "^11.2.7"
+				"@csstools/css-tokenizer": "^4.0.0"
 			},
 			"engines": {
 				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
 			}
 		},
 		"node_modules/@asamuzakjp/dom-selector": {
-			"version": "7.0.4",
-			"resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.0.4.tgz",
-			"integrity": "sha512-jXR6x4AcT3eIrS2fSNAwJpwirOkGcd+E7F7CP3zjdTqz9B/2huHOL8YJZBgekKwLML+u7qB/6P1LXQuMScsx0w==",
+			"version": "7.0.9",
+			"resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.0.9.tgz",
+			"integrity": "sha512-r3ElRr7y8ucyN2KdICwGsmj19RoN13CLCa/pvGydghWK6ZzeKQ+TcDjVdtEZz2ElpndM5jXw//B9CEee0mWnVg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@asamuzakjp/nwsapi": "^2.3.9",
 				"bidi-js": "^1.0.3",
 				"css-tree": "^3.2.1",
-				"is-potential-custom-element-name": "^1.0.1",
-				"lru-cache": "^11.2.7"
+				"is-potential-custom-element-name": "^1.0.1"
 			},
 			"engines": {
 				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
@@ -258,9 +256,9 @@
 			}
 		},
 		"node_modules/@csstools/css-calc": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.1.1.tgz",
-			"integrity": "sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.0.tgz",
+			"integrity": "sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==",
 			"dev": true,
 			"funding": [
 				{
@@ -282,9 +280,9 @@
 			}
 		},
 		"node_modules/@csstools/css-color-parser": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.0.2.tgz",
-			"integrity": "sha512-0GEfbBLmTFf0dJlpsNU7zwxRIH0/BGEMuXLTCvFYxuL1tNhqzTbtnFICyJLTNK4a+RechKP75e7w42ClXSnJQw==",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.0.tgz",
+			"integrity": "sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -299,7 +297,7 @@
 			"license": "MIT",
 			"dependencies": {
 				"@csstools/color-helpers": "^6.0.2",
-				"@csstools/css-calc": "^3.1.1"
+				"@csstools/css-calc": "^3.2.0"
 			},
 			"engines": {
 				"node": ">=20.19.0"
@@ -1235,16 +1233,16 @@
 			}
 		},
 		"node_modules/@vitest/expect": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.2.tgz",
-			"integrity": "sha512-gbu+7B0YgUJ2nkdsRJrFFW6X7NTP44WlhiclHniUhxADQJH5Szt9mZ9hWnJPJ8YwOK5zUOSSlSvyzRf0u1DSBQ==",
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.3.tgz",
+			"integrity": "sha512-CW8Q9KMtXDGHj0vCsqui0M5KqRsu0zm0GNDW7Gd3U7nZ2RFpPKSCpeCXoT+/+5zr1TNlsoQRDEz+LzZUyq6gnQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@standard-schema/spec": "^1.1.0",
 				"@types/chai": "^5.2.2",
-				"@vitest/spy": "4.1.2",
-				"@vitest/utils": "4.1.2",
+				"@vitest/spy": "4.1.3",
+				"@vitest/utils": "4.1.3",
 				"chai": "^6.2.2",
 				"tinyrainbow": "^3.1.0"
 			},
@@ -1253,13 +1251,13 @@
 			}
 		},
 		"node_modules/@vitest/mocker": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.2.tgz",
-			"integrity": "sha512-Ize4iQtEALHDttPRCmN+FKqOl2vxTiNUhzobQFFt/BM1lRUTG7zRCLOykG/6Vo4E4hnUdfVLo5/eqKPukcWW7Q==",
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.3.tgz",
+			"integrity": "sha512-XN3TrycitDQSzGRnec/YWgoofkYRhouyVQj4YNsJ5r/STCUFqMrP4+oxEv3e7ZbLi4og5kIHrZwekDJgw6hcjw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/spy": "4.1.2",
+				"@vitest/spy": "4.1.3",
 				"estree-walker": "^3.0.3",
 				"magic-string": "^0.30.21"
 			},
@@ -1280,9 +1278,9 @@
 			}
 		},
 		"node_modules/@vitest/pretty-format": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.2.tgz",
-			"integrity": "sha512-dwQga8aejqeuB+TvXCMzSQemvV9hNEtDDpgUKDzOmNQayl2OG241PSWeJwKRH3CiC+sESrmoFd49rfnq7T4RnA==",
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.3.tgz",
+			"integrity": "sha512-hYqqwuMbpkkBodpRh4k4cQSOELxXky1NfMmQvOfKvV8zQHz8x8Dla+2wzElkMkBvSAJX5TRGHJAQvK0TcOafwg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1293,13 +1291,13 @@
 			}
 		},
 		"node_modules/@vitest/runner": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.2.tgz",
-			"integrity": "sha512-Gr+FQan34CdiYAwpGJmQG8PgkyFVmARK8/xSijia3eTFgVfpcpztWLuP6FttGNfPLJhaZVP/euvujeNYar36OQ==",
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.3.tgz",
+			"integrity": "sha512-VwgOz5MmT0KhlUj40h02LWDpUBVpflZ/b7xZFA25F29AJzIrE+SMuwzFf0b7t4EXdwRNX61C3B6auIXQTR3ttA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/utils": "4.1.2",
+				"@vitest/utils": "4.1.3",
 				"pathe": "^2.0.3"
 			},
 			"funding": {
@@ -1307,14 +1305,14 @@
 			}
 		},
 		"node_modules/@vitest/snapshot": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.2.tgz",
-			"integrity": "sha512-g7yfUmxYS4mNxk31qbOYsSt2F4m1E02LFqO53Xpzg3zKMhLAPZAjjfyl9e6z7HrW6LvUdTwAQR3HHfLjpko16A==",
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.3.tgz",
+			"integrity": "sha512-9l+k/J9KG5wPJDX9BcFFzhhwNjwkRb8RsnYhaT1vPY7OufxmQFc9sZzScRCPTiETzl37mrIWVY9zxzmdVeJwDQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/pretty-format": "4.1.2",
-				"@vitest/utils": "4.1.2",
+				"@vitest/pretty-format": "4.1.3",
+				"@vitest/utils": "4.1.3",
 				"magic-string": "^0.30.21",
 				"pathe": "^2.0.3"
 			},
@@ -1323,9 +1321,9 @@
 			}
 		},
 		"node_modules/@vitest/spy": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.2.tgz",
-			"integrity": "sha512-DU4fBnbVCJGNBwVA6xSToNXrkZNSiw59H8tcuUspVMsBDBST4nfvsPsEHDHGtWRRnqBERBQu7TrTKskmjqTXKA==",
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.3.tgz",
+			"integrity": "sha512-ujj5Uwxagg4XUIfAUyRQxAg631BP6e9joRiN99mr48Bg9fRs+5mdUElhOoZ6rP5mBr8Bs3lmrREnkrQWkrsTCw==",
 			"dev": true,
 			"license": "MIT",
 			"funding": {
@@ -1333,13 +1331,13 @@
 			}
 		},
 		"node_modules/@vitest/utils": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.2.tgz",
-			"integrity": "sha512-xw2/TiX82lQHA06cgbqRKFb5lCAy3axQ4H4SoUFhUsg+wztiet+co86IAMDtF6Vm1hc7J6j09oh/rgDn+JdKIQ==",
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.3.tgz",
+			"integrity": "sha512-Pc/Oexse/khOWsGB+w3q4yzA4te7W4gpZZAvk+fr8qXfTURZUMj5i7kuxsNK5mP/dEB6ao3jfr0rs17fHhbHdw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/pretty-format": "4.1.2",
+				"@vitest/pretty-format": "4.1.3",
 				"convert-source-map": "^2.0.0",
 				"tinyrainbow": "^3.1.0"
 			},
@@ -1952,14 +1950,14 @@
 			}
 		},
 		"node_modules/jsdom": {
-			"version": "29.0.1",
-			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.0.1.tgz",
-			"integrity": "sha512-z6JOK5gRO7aMybVq/y/MlIpKh8JIi68FBKMUtKkK2KH/wMSRlCxQ682d08LB9fYXplyY/UXG8P4XXTScmdjApg==",
+			"version": "29.0.2",
+			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.0.2.tgz",
+			"integrity": "sha512-9VnGEBosc/ZpwyOsJBCQ/3I5p7Q5ngOY14a9bf5btenAORmZfDse1ZEheMiWcJ3h81+Fv7HmJFdS0szo/waF2w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@asamuzakjp/css-color": "^5.0.1",
-				"@asamuzakjp/dom-selector": "^7.0.3",
+				"@asamuzakjp/css-color": "^5.1.5",
+				"@asamuzakjp/dom-selector": "^7.0.6",
 				"@bramus/specificity": "^2.4.2",
 				"@csstools/css-syntax-patches-for-csstree": "^1.1.1",
 				"@exodus/bytes": "^1.15.0",
@@ -2315,9 +2313,9 @@
 			}
 		},
 		"node_modules/lru-cache": {
-			"version": "11.2.7",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
-			"integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
+			"version": "11.3.5",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+			"integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
 			"dev": true,
 			"license": "BlueOak-1.0.0",
 			"engines": {
@@ -3039,19 +3037,19 @@
 			}
 		},
 		"node_modules/vitest": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.2.tgz",
-			"integrity": "sha512-xjR1dMTVHlFLh98JE3i/f/WePqJsah4A0FK9cc8Ehp9Udk0AZk6ccpIZhh1qJ/yxVWRZ+Q54ocnD8TXmkhspGg==",
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.3.tgz",
+			"integrity": "sha512-DBc4Tx0MPNsqb9isoyOq00lHftVx/KIU44QOm2q59npZyLUkENn8TMFsuzuO+4U2FUa9rgbbPt3udrP25GcjXw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/expect": "4.1.2",
-				"@vitest/mocker": "4.1.2",
-				"@vitest/pretty-format": "4.1.2",
-				"@vitest/runner": "4.1.2",
-				"@vitest/snapshot": "4.1.2",
-				"@vitest/spy": "4.1.2",
-				"@vitest/utils": "4.1.2",
+				"@vitest/expect": "4.1.3",
+				"@vitest/mocker": "4.1.3",
+				"@vitest/pretty-format": "4.1.3",
+				"@vitest/runner": "4.1.3",
+				"@vitest/snapshot": "4.1.3",
+				"@vitest/spy": "4.1.3",
+				"@vitest/utils": "4.1.3",
 				"es-module-lexer": "^2.0.0",
 				"expect-type": "^1.3.0",
 				"magic-string": "^0.30.21",
@@ -3079,10 +3077,12 @@
 				"@edge-runtime/vm": "*",
 				"@opentelemetry/api": "^1.9.0",
 				"@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-				"@vitest/browser-playwright": "4.1.2",
-				"@vitest/browser-preview": "4.1.2",
-				"@vitest/browser-webdriverio": "4.1.2",
-				"@vitest/ui": "4.1.2",
+				"@vitest/browser-playwright": "4.1.3",
+				"@vitest/browser-preview": "4.1.3",
+				"@vitest/browser-webdriverio": "4.1.3",
+				"@vitest/coverage-istanbul": "4.1.3",
+				"@vitest/coverage-v8": "4.1.3",
+				"@vitest/ui": "4.1.3",
 				"happy-dom": "*",
 				"jsdom": "*",
 				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -3104,6 +3104,12 @@
 					"optional": true
 				},
 				"@vitest/browser-webdriverio": {
+					"optional": true
+				},
+				"@vitest/coverage-istanbul": {
+					"optional": true
+				},
+				"@vitest/coverage-v8": {
 					"optional": true
 				},
 				"@vitest/ui": {

--- a/package.json
+++ b/package.json
@@ -57,11 +57,11 @@
 		"@biomejs/biome": "2.4.10",
 		"@playwright/test": "1.59.1",
 		"eslint": "10.2.0",
-		"jsdom": "29.0.1",
+		"jsdom": "29.0.2",
 		"terser": "5.46.1",
 		"typescript": "6.0.2",
 		"typescript-eslint": "8.58.0",
 		"vite": "8.0.7",
-		"vitest": "4.1.2"
+		"vitest": "4.1.3"
 	}
 }


### PR DESCRIPTION
## 概要
- devDependency のパッチアップデート

## 変更内容
- jsdom 29.0.1 → 29.0.2
- vitest 4.1.2 → 4.1.3

## テスト計画
- `npm test`: 82 件パス
- `npm run check`: パス

Closes #51