### PR TITLE
chore: typescript-eslint 8.58.1 + dep-check Node.js バージョン修正

### DIFF
--- a/.github/workflows/dep-check.yml
+++ b/.github/workflows/dep-check.yml
@@ -47,9 +47,17 @@ jobs:
             REPORT="${REPORT}\n📦 Node.js アップデート: v${NODE_CURRENT} → v${LATEST}"
           fi
 
+          # mise.toml のバージョンと実際のバージョンを比較
+          MISE_NODE=$(grep 'node' mise.toml | sed 's/.*"\(.*\)".*/\1/')
+          ACTUAL_NODE=$(node -v | sed 's/v//')
+          if [ "$MISE_NODE" != "$ACTUAL_NODE" ]; then
+            REPORT="${REPORT}\n⚠️ Node.js バージョン不一致: mise.toml=${MISE_NODE}, 実際=${ACTUAL_NODE}"
+          fi
+
           echo "report<<EOF" >> "$GITHUB_OUTPUT"
           echo -e "$REPORT" >> "$GITHUB_OUTPUT"
           echo "EOF" >> "$GITHUB_OUTPUT"
+          echo "version=$(node -v)" >> "$GITHUB_OUTPUT"
 
       # npm-check-updates でアップデートチェック
       - name: Check patch updates
@@ -94,6 +102,7 @@ jobs:
           MINOR: ${{ steps.minor.outputs.result }}
           MAJOR: ${{ steps.major.outputs.result }}
           AUDIT: ${{ steps.audit.outputs.result }}
+          NODE_VERSION: ${{ steps.node-eol.outputs.version }}
         with:
           script: |
             const nodeEol = process.env.NODE_EOL?.trim() || '';
@@ -153,7 +162,7 @@ jobs:
 
             let body = `# 依存性チェックレポート\n\n`;
             body += `**実行日**: ${today}\n`;
-            body += `**Node.js**: ${process.version}\n\n`;
+            body += `**Node.js**: ${process.env.NODE_VERSION}\n\n`;
 
             if (nodeEol) {
               body += `## Node.js ステータス\n\n${nodeEol}\n\n`;

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
 				"jsdom": "29.0.2",
 				"terser": "5.46.1",
 				"typescript": "6.0.2",
-				"typescript-eslint": "8.58.0",
+				"typescript-eslint": "8.58.1",
 				"vite": "8.0.7",
 				"vitest": "4.1.3"
 			}
@@ -1003,17 +1003,17 @@
 			"license": "MIT"
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
-			"version": "8.58.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.58.0.tgz",
-			"integrity": "sha512-RLkVSiNuUP1C2ROIWfqX+YcUfLaSnxGE/8M+Y57lopVwg9VTYYfhuz15Yf1IzCKgZj6/rIbYTmJCUSqr76r0Wg==",
+			"version": "8.58.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.58.1.tgz",
+			"integrity": "sha512-eSkwoemjo76bdXl2MYqtxg51HNwUSkWfODUOQ3PaTLZGh9uIWWFZIjyjaJnex7wXDu+TRx+ATsnSxdN9YWfRTQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/regexpp": "^4.12.2",
-				"@typescript-eslint/scope-manager": "8.58.0",
-				"@typescript-eslint/type-utils": "8.58.0",
-				"@typescript-eslint/utils": "8.58.0",
-				"@typescript-eslint/visitor-keys": "8.58.0",
+				"@typescript-eslint/scope-manager": "8.58.1",
+				"@typescript-eslint/type-utils": "8.58.1",
+				"@typescript-eslint/utils": "8.58.1",
+				"@typescript-eslint/visitor-keys": "8.58.1",
 				"ignore": "^7.0.5",
 				"natural-compare": "^1.4.0",
 				"ts-api-utils": "^2.5.0"
@@ -1026,7 +1026,7 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"@typescript-eslint/parser": "^8.58.0",
+				"@typescript-eslint/parser": "^8.58.1",
 				"eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
 				"typescript": ">=4.8.4 <6.1.0"
 			}
@@ -1042,16 +1042,16 @@
 			}
 		},
 		"node_modules/@typescript-eslint/parser": {
-			"version": "8.58.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.58.0.tgz",
-			"integrity": "sha512-rLoGZIf9afaRBYsPUMtvkDWykwXwUPL60HebR4JgTI8mxfFe2cQTu3AGitANp4b9B2QlVru6WzjgB2IzJKiCSA==",
+			"version": "8.58.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.58.1.tgz",
+			"integrity": "sha512-gGkiNMPqerb2cJSVcruigx9eHBlLG14fSdPdqMoOcBfh+vvn4iCq2C8MzUB89PrxOXk0y3GZ1yIWb9aOzL93bw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "8.58.0",
-				"@typescript-eslint/types": "8.58.0",
-				"@typescript-eslint/typescript-estree": "8.58.0",
-				"@typescript-eslint/visitor-keys": "8.58.0",
+				"@typescript-eslint/scope-manager": "8.58.1",
+				"@typescript-eslint/types": "8.58.1",
+				"@typescript-eslint/typescript-estree": "8.58.1",
+				"@typescript-eslint/visitor-keys": "8.58.1",
 				"debug": "^4.4.3"
 			},
 			"engines": {
@@ -1067,14 +1067,14 @@
 			}
 		},
 		"node_modules/@typescript-eslint/project-service": {
-			"version": "8.58.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.58.0.tgz",
-			"integrity": "sha512-8Q/wBPWLQP1j16NxoPNIKpDZFMaxl7yWIoqXWYeWO+Bbd2mjgvoF0dxP2jKZg5+x49rgKdf7Ck473M8PC3V9lg==",
+			"version": "8.58.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.58.1.tgz",
+			"integrity": "sha512-gfQ8fk6cxhtptek+/8ZIqw8YrRW5048Gug8Ts5IYcMLCw18iUgrZAEY/D7s4hkI0FxEfGakKuPK/XUMPzPxi5g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/tsconfig-utils": "^8.58.0",
-				"@typescript-eslint/types": "^8.58.0",
+				"@typescript-eslint/tsconfig-utils": "^8.58.1",
+				"@typescript-eslint/types": "^8.58.1",
 				"debug": "^4.4.3"
 			},
 			"engines": {
@@ -1089,14 +1089,14 @@
 			}
 		},
 		"node_modules/@typescript-eslint/scope-manager": {
-			"version": "8.58.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.58.0.tgz",
-			"integrity": "sha512-W1Lur1oF50FxSnNdGp3Vs6P+yBRSmZiw4IIjEeYxd8UQJwhUF0gDgDD/W/Tgmh73mxgEU3qX0Bzdl/NGuSPEpQ==",
+			"version": "8.58.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.58.1.tgz",
+			"integrity": "sha512-TPYUEqJK6avLcEjumWsIuTpuYODTTDAtoMdt8ZZa93uWMTX13Nb8L5leSje1NluammvU+oI3QRr5lLXPgihX3w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.58.0",
-				"@typescript-eslint/visitor-keys": "8.58.0"
+				"@typescript-eslint/types": "8.58.1",
+				"@typescript-eslint/visitor-keys": "8.58.1"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1107,9 +1107,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/tsconfig-utils": {
-			"version": "8.58.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.58.0.tgz",
-			"integrity": "sha512-doNSZEVJsWEu4htiVC+PR6NpM+pa+a4ClH9INRWOWCUzMst/VA9c4gXq92F8GUD1rwhNvRLkgjfYtFXegXQF7A==",
+			"version": "8.58.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.58.1.tgz",
+			"integrity": "sha512-JAr2hOIct2Q+qk3G+8YFfqkqi7sC86uNryT+2i5HzMa2MPjw4qNFvtjnw1IiA1rP7QhNKVe21mSSLaSjwA1Olw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -1124,15 +1124,15 @@
 			}
 		},
 		"node_modules/@typescript-eslint/type-utils": {
-			"version": "8.58.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.58.0.tgz",
-			"integrity": "sha512-aGsCQImkDIqMyx1u4PrVlbi/krmDsQUs4zAcCV6M7yPcPev+RqVlndsJy9kJ8TLihW9TZ0kbDAzctpLn5o+lOg==",
+			"version": "8.58.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.58.1.tgz",
+			"integrity": "sha512-HUFxvTJVroT+0rXVJC7eD5zol6ID+Sn5npVPWoFuHGg9Ncq5Q4EYstqR+UOqaNRFXi5TYkpXXkLhoCHe3G0+7w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.58.0",
-				"@typescript-eslint/typescript-estree": "8.58.0",
-				"@typescript-eslint/utils": "8.58.0",
+				"@typescript-eslint/types": "8.58.1",
+				"@typescript-eslint/typescript-estree": "8.58.1",
+				"@typescript-eslint/utils": "8.58.1",
 				"debug": "^4.4.3",
 				"ts-api-utils": "^2.5.0"
 			},
@@ -1149,9 +1149,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/types": {
-			"version": "8.58.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.58.0.tgz",
-			"integrity": "sha512-O9CjxypDT89fbHxRfETNoAnHj/i6IpRK0CvbVN3qibxlLdo5p5hcLmUuCCrHMpxiWSwKyI8mCP7qRNYuOJ0Uww==",
+			"version": "8.58.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.58.1.tgz",
+			"integrity": "sha512-io/dV5Aw5ezwzfPBBWLoT+5QfVtP8O7q4Kftjn5azJ88bYyp/ZMCsyW1lpKK46EXJcaYMZ1JtYj+s/7TdzmQMw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -1163,16 +1163,16 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree": {
-			"version": "8.58.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.58.0.tgz",
-			"integrity": "sha512-7vv5UWbHqew/dvs+D3e1RvLv1v2eeZ9txRHPnEEBUgSNLx5ghdzjHa0sgLWYVKssH+lYmV0JaWdoubo0ncGYLA==",
+			"version": "8.58.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.58.1.tgz",
+			"integrity": "sha512-w4w7WR7GHOjqqPnvAYbazq+Y5oS68b9CzasGtnd6jIeOIeKUzYzupGTB2T4LTPSv4d+WPeccbxuneTFHYgAAWg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/project-service": "8.58.0",
-				"@typescript-eslint/tsconfig-utils": "8.58.0",
-				"@typescript-eslint/types": "8.58.0",
-				"@typescript-eslint/visitor-keys": "8.58.0",
+				"@typescript-eslint/project-service": "8.58.1",
+				"@typescript-eslint/tsconfig-utils": "8.58.1",
+				"@typescript-eslint/types": "8.58.1",
+				"@typescript-eslint/visitor-keys": "8.58.1",
 				"debug": "^4.4.3",
 				"minimatch": "^10.2.2",
 				"semver": "^7.7.3",
@@ -1191,16 +1191,16 @@
 			}
 		},
 		"node_modules/@typescript-eslint/utils": {
-			"version": "8.58.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.58.0.tgz",
-			"integrity": "sha512-RfeSqcFeHMHlAWzt4TBjWOAtoW9lnsAGiP3GbaX9uVgTYYrMbVnGONEfUCiSss+xMHFl+eHZiipmA8WkQ7FuNA==",
+			"version": "8.58.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.58.1.tgz",
+			"integrity": "sha512-Ln8R0tmWC7pTtLOzgJzYTXSCjJ9rDNHAqTaVONF4FEi2qwce8mD9iSOxOpLFFvWp/wBFlew0mjM1L1ihYWfBdQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.9.1",
-				"@typescript-eslint/scope-manager": "8.58.0",
-				"@typescript-eslint/types": "8.58.0",
-				"@typescript-eslint/typescript-estree": "8.58.0"
+				"@typescript-eslint/scope-manager": "8.58.1",
+				"@typescript-eslint/types": "8.58.1",
+				"@typescript-eslint/typescript-estree": "8.58.1"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1215,13 +1215,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/visitor-keys": {
-			"version": "8.58.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.58.0.tgz",
-			"integrity": "sha512-XJ9UD9+bbDo4a4epraTwG3TsNPeiB9aShrUneAVXy8q4LuwowN+qu89/6ByLMINqvIMeI9H9hOHQtg/ijrYXzQ==",
+			"version": "8.58.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.58.1.tgz",
+			"integrity": "sha512-y+vH7QE8ycjoa0bWciFg7OpFcipUuem1ujhrdLtq1gByKwfbC7bPeKsiny9e0urg93DqwGcHey+bGRKCnF1nZQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.58.0",
+				"@typescript-eslint/types": "8.58.1",
 				"eslint-visitor-keys": "^5.0.0"
 			},
 			"engines": {
@@ -2915,16 +2915,16 @@
 			}
 		},
 		"node_modules/typescript-eslint": {
-			"version": "8.58.0",
-			"resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.58.0.tgz",
-			"integrity": "sha512-e2TQzKfaI85fO+F3QywtX+tCTsu/D3WW5LVU6nz8hTFKFZ8yBJ6mSYRpXqdR3mFjPWmO0eWsTa5f+UpAOe/FMA==",
+			"version": "8.58.1",
+			"resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.58.1.tgz",
+			"integrity": "sha512-gf6/oHChByg9HJvhMO1iBexJh12AqqTfnuxscMDOVqfJW3htsdRJI/GfPpHTTcyeB8cSTUY2JcZmVgoyPqcrDg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/eslint-plugin": "8.58.0",
-				"@typescript-eslint/parser": "8.58.0",
-				"@typescript-eslint/typescript-estree": "8.58.0",
-				"@typescript-eslint/utils": "8.58.0"
+				"@typescript-eslint/eslint-plugin": "8.58.1",
+				"@typescript-eslint/parser": "8.58.1",
+				"@typescript-eslint/typescript-estree": "8.58.1",
+				"@typescript-eslint/utils": "8.58.1"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
 		"jsdom": "29.0.2",
 		"terser": "5.46.1",
 		"typescript": "6.0.2",
-		"typescript-eslint": "8.58.0",
+		"typescript-eslint": "8.58.1",
 		"vite": "8.0.7",
 		"vitest": "4.1.3"
 	}


### PR DESCRIPTION
## 概要
- Issue #54 の依存性レポートに基づく対応

## 変更内容
- typescript-eslint 8.58.0 → 8.58.1 パッチアップデート
- dep-check.yml: Node.js バージョン表示を `process.version`（ランナーデフォルト）から `node -v`（mise でインストールした実際のバージョン）に修正
- dep-check.yml: mise.toml との Node.js バージョン一致チェックを追加

## テスト計画
- [x] `npm run check` パス
- [x] `npm run test` 82テスト全通過
- [x] `npm run build` 成功
- [ ] dep-check.yml の動作は次回の定期実行 or workflow_dispatch で確認

Closes #54