### PR TITLE
fix(demo): HTML に Cache-Control メタタグを追加してキャッシュを防止

### DIFF
--- a/demo/dock.html
+++ b/demo/dock.html
@@ -4,6 +4,9 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="color-scheme" content="dark" />
+  <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+  <meta http-equiv="Pragma" content="no-cache">
+  <meta http-equiv="Expires" content="0">
   <title>TileUI - Dock Demo</title>
 
   <!-- Google Fonts -->

--- a/demo/index.html
+++ b/demo/index.html
@@ -4,6 +4,9 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="color-scheme" content="dark" />
+  <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+  <meta http-equiv="Pragma" content="no-cache">
+  <meta http-equiv="Expires" content="0">
   <title>TileUI - A Grid-Tile GUI Panel for Creative Coding</title>
   <meta name="description" content="A grid-tile GUI panel with SVG rotary knobs for creative coding. Inspired by lil-gui / dat.gui / Tweakpane." />
 


### PR DESCRIPTION
## 概要
- デモサイトの HTML にキャッシュ制御メタタグを追加し、ブラウザキャッシュによる古いアセット配信を防止

## 変更内容
- `demo/index.html`, `demo/dock.html` に Cache-Control, Pragma, Expires メタタグを追加
- Vite は JS/CSS にコンテンツハッシュを付与するが、HTML 自体がキャッシュされると新しいアセットが読み込まれないため、HTML のキャッシュを無効化

## テスト計画
- [x] `npm run build:demo` 成功、出力 HTML にメタタグ反映確認
- [x] `npm run check` / `npm run test` / `npm run build` パス