### PR TITLE
fix(e2e): playwright を専用ポート 5174 + strictPort に変更

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,18 +1,23 @@
 import { defineConfig, devices } from '@playwright/test';
 
+// E2E 専用ポート。開発用 5173 と分離し、別の vite プロセスとの衝突を避ける
+const E2E_PORT = 5174;
+const E2E_BASE_URL = `http://localhost:${E2E_PORT}`;
+
 export default defineConfig({
 	testDir: './e2e',
 	timeout: 30_000,
 	retries: 0,
 	use: {
-		baseURL: 'http://localhost:5173',
+		baseURL: E2E_BASE_URL,
 		screenshot: 'only-on-failure',
 	},
 	// demo ページの Vite dev server を自動起動
+	// --strictPort で別ポートへのフォールバックを禁止し、baseURL とのズレを早期に検出する
 	webServer: {
-		command: 'npm run dev',
-		url: 'http://localhost:5173',
-		reuseExistingServer: true,
+		command: `pnpm exec vite --strictPort --port=${E2E_PORT}`,
+		url: E2E_BASE_URL,
+		reuseExistingServer: !process.env.CI,
 	},
 	projects: [
 		{


### PR DESCRIPTION
## 概要

- `playwright.config.ts` のみ修正（+9 -4）
- E2E 専用ポート 5174 を導入し、開発用 5173 との衝突を解消
- `pnpm exec vite --strictPort --port=5174` でポートフォールバックを禁止
- `reuseExistingServer: !process.env.CI` に変更し、CI では常に新規起動

## 変更内容

ローカルで 5173 を別の vite プロセスが占有している場合に E2E テストが誤ったサーバーに接続して失敗する事象を修正。

- `baseURL` を `http://localhost:5174` に変更
- `webServer.command` を `pnpm exec vite --strictPort --port=5174` に変更
- `reuseExistingServer` を `!process.env.CI`（CI では `false`、ローカルでは `true`）に変更

## テスト結果

- `pnpm run test:e2e`: 15 passed, 1 skipped, 0 failed
- `pnpm run test`: 82 passed
- `pnpm run check`: 警告ゼロ
- `pnpm run build`: 成功