### PR TITLE
chore(demo): フォントを Outfit / Silkscreen に差し替え、自明なコメントを削除

### DIFF
--- a/demo/dock.html
+++ b/demo/dock.html
@@ -20,9 +20,14 @@
   <!-- Google Fonts -->
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500&family=Space+Mono&display=swap" rel="stylesheet" />
+  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;500&family=Silkscreen:wght@400;700&family=Space+Mono&display=swap" rel="stylesheet" />
 
   <style>
+    /* フォント切り替え: 使いたい方のコメントを外す */
+    :root {
+      --demo-font: "Silkscreen", cursive;
+    }
+
     /* リセットとベース */
     *, *::before, *::after {
       box-sizing: border-box;
@@ -32,7 +37,7 @@
 
     body {
       color: #faf9f6;
-      font-family: "Space Grotesk", sans-serif;
+      font-family: var(--demo-font);
       min-height: 100vh;
       display: flex;
       flex-direction: column;
@@ -55,7 +60,7 @@
       --tileui-knob-track: #333333;
       --tileui-knob-thumb: #faf9f6;
       --tileui-toggle-off: #333333;
-      --tileui-font-family: "Space Grotesk", sans-serif;
+      --tileui-font-family: "Outfit", sans-serif;
     }
 
     .tileui-drawer {
@@ -83,7 +88,7 @@
       align-items: center;
       justify-content: space-between;
       padding: 16px 24px;
-      font-family: "Space Mono", monospace;
+      font-family: var(--demo-font);
       font-size: 12px;
       text-transform: uppercase;
       letter-spacing: 0.12em;
@@ -113,7 +118,7 @@
     }
 
     .dock-center__title {
-      font-family: "Space Mono", monospace;
+      font-family: var(--demo-font);
       font-size: clamp(20px, 4vw, 32px);
       font-weight: 400;
       letter-spacing: 0.15em;
@@ -129,7 +134,7 @@
 
     .dock-center__hint {
       margin-top: 24px;
-      font-family: "Space Mono", monospace;
+      font-family: var(--demo-font);
       font-size: 12px;
       color: #555555;
       letter-spacing: 0.05em;
@@ -149,7 +154,7 @@
     /* 方向ラベル */
     .dock-center__direction {
       margin-top: 12px;
-      font-family: "Space Mono", monospace;
+      font-family: var(--demo-font);
       font-size: 12px;
       color: #555555;
       letter-spacing: 0.1em;
@@ -172,8 +177,8 @@
   <div class="dock-center">
     <h1 class="dock-center__title">Dock Demo</h1>
     <p class="dock-center__desc">
-      TileUI のドロワー（Dock）モードのデモです。<br />
-      パネル内のボタンでドック方向を切り替えられます。
+      A demo of TileUI's drawer (Dock) mode.<br />
+      Use the buttons in the panel to switch dock direction.
     </p>
     <p class="dock-center__hint">
       Press <kbd>G</kbd> to toggle drawer

--- a/demo/dock.html
+++ b/demo/dock.html
@@ -9,7 +9,6 @@
   <meta http-equiv="Expires" content="0">
   <title>TileUI - Dock Demo</title>
 
-  <!-- Favicon / アイコン -->
   <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png" />
   <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16.png" />
   <link rel="icon" type="image/png" sizes="192x192" href="/favicon-192.png" />
@@ -17,18 +16,15 @@
   <link rel="manifest" href="/site.webmanifest" />
   <meta name="theme-color" content="#0a0a0a" />
 
-  <!-- Google Fonts -->
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;500&family=Silkscreen:wght@400;700&family=Space+Mono&display=swap" rel="stylesheet" />
 
   <style>
-    /* フォント切り替え: 使いたい方のコメントを外す */
     :root {
       --demo-font: "Silkscreen", cursive;
     }
 
-    /* リセットとベース */
     *, *::before, *::after {
       box-sizing: border-box;
       margin: 0;
@@ -47,7 +43,6 @@
       -moz-osx-font-smoothing: grayscale;
     }
 
-    /* tileui パネルのスタイルオーバーライド（メインデモと統一） */
     .tileui-panel {
       --tileui-bg: #000000;
       --tileui-tile-bg: #000000;
@@ -69,7 +64,6 @@
       padding: 4px;
     }
 
-    /* ヘッダー・中央テキストの視認性確保 */
     .dock-header,
     .dock-center__title,
     .dock-center__desc,
@@ -78,7 +72,6 @@
       text-shadow: 0 0 20px rgba(0,0,0,0.8);
     }
 
-    /* ヘッダー */
     .dock-header {
       position: fixed;
       top: 0;
@@ -110,7 +103,6 @@
       color: #faf9f6;
     }
 
-    /* 中央テキスト */
     .dock-center {
       text-align: center;
       max-width: 480px;
@@ -151,7 +143,6 @@
       color: #faf9f6;
     }
 
-    /* 方向ラベル */
     .dock-center__direction {
       margin-top: 12px;
       font-family: var(--demo-font);
@@ -167,13 +158,11 @@
   </style>
 </head>
 <body>
-  <!-- ヘッダー -->
   <header class="dock-header">
     <span class="dock-header__logo">TILEUI</span>
     <a class="dock-header__link" href="./index.html">&larr; Main Demo</a>
   </header>
 
-  <!-- 中央コンテンツ -->
   <div class="dock-center">
     <h1 class="dock-center__title">Dock Demo</h1>
     <p class="dock-center__desc">

--- a/demo/index.html
+++ b/demo/index.html
@@ -10,7 +10,6 @@
   <title>TileUI - A Grid-Tile GUI Panel for Creative Coding</title>
   <meta name="description" content="A grid-tile GUI panel with SVG rotary knobs for creative coding. Inspired by lil-gui / dat.gui / Tweakpane." />
 
-  <!-- Favicon / アイコン -->
   <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png" />
   <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16.png" />
   <link rel="icon" type="image/png" sizes="192x192" href="/favicon-192.png" />
@@ -18,13 +17,11 @@
   <link rel="manifest" href="/site.webmanifest" />
   <meta name="theme-color" content="#0a0a0a" />
 
-  <!-- OGP -->
   <meta property="og:title" content="TileUI — Grid-Tile GUI Panel for Creative Coding" />
   <meta property="og:description" content="A grid-tile GUI panel with SVG rotary knobs for creative coding. Inspired by lil-gui / dat.gui / Tweakpane." />
   <meta property="og:type" content="website" />
   <meta property="og:url" content="https://tileui.yuske.app" />
 
-  <!-- Google Fonts -->
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;500&family=Silkscreen:wght@400;700&family=Space+Mono&display=swap" rel="stylesheet" />
@@ -33,7 +30,6 @@
   <script src="https://cdn.jsdelivr.net/npm/p5@1/lib/p5.min.js"></script>
 </head>
 <body>
-  <!-- ヘッダー -->
   <header class="header">
     <span class="header__logo">TILEUI</span>
     <nav class="header__nav">
@@ -44,23 +40,19 @@
     </nav>
   </header>
 
-  <!-- メインエリア: キャンバス + GUI パネル -->
   <main class="main">
     <div id="sketch" class="canvas-area"></div>
     <div id="gui" class="gui-area"></div>
   </main>
 
-  <!-- タグライン -->
   <section class="tagline">
     <p>A grid-tile GUI panel with SVG rotary knobs for creative coding</p>
   </section>
 
-  <!-- インストールコマンド -->
   <section class="install">
     <code class="install__command" id="install-cmd" title="Click to copy">npm install @yuske-nakajima/tileui</code>
   </section>
 
-  <!-- 使い方 -->
   <section class="usage">
     <h2 class="usage__title">USAGE</h2>
     <div class="usage__item">
@@ -82,7 +74,6 @@
     </div>
   </section>
 
-  <!-- ショーケース -->
   <section class="showcase">
     <h2 class="showcase__title">EXAMPLES</h2>
 
@@ -126,13 +117,11 @@ gui.open();</code></pre>
     </div>
   </section>
 
-  <!-- ドックデモへの誘導 -->
   <section class="dock-cta">
     <p>Try the interactive dock demo with all four directions</p>
     <a href="./dock.html">Go to Dock Demo &rarr;</a>
   </section>
 
-  <!-- フッター -->
   <footer class="footer">
     <span>KNOB</span>
     <span class="footer__dot">&middot;</span>

--- a/demo/index.html
+++ b/demo/index.html
@@ -27,7 +27,7 @@
   <!-- Google Fonts -->
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500&family=Space+Mono&display=swap" rel="stylesheet" />
+  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;500&family=Silkscreen:wght@400;700&family=Space+Mono&display=swap" rel="stylesheet" />
 
   <link rel="stylesheet" href="./style.css" />
   <script src="https://cdn.jsdelivr.net/npm/p5@1/lib/p5.min.js"></script>

--- a/demo/style.css
+++ b/demo/style.css
@@ -1,5 +1,10 @@
 /* === tileui デモページ — Nothing design スタイル === */
 
+/* フォント切り替え: 使いたい方のコメントを外す */
+:root {
+	--demo-font: "Silkscreen", cursive;
+}
+
 /*
  * tileui CSS 変数のモノクロオーバーライド
  * ライブラリの injectStyles() が :root に後から注入するため、
@@ -17,7 +22,7 @@
 	--tileui-knob-track: #333333;
 	--tileui-knob-thumb: #faf9f6;
 	--tileui-toggle-off: #333333;
-	--tileui-font-family: "Space Grotesk", sans-serif;
+	--tileui-font-family: "Outfit", sans-serif;
 }
 
 /* ダークモード: スクロールバー等もダークにする */
@@ -37,7 +42,7 @@ html {
 body {
 	background: #000000;
 	color: #faf9f6;
-	font-family: "Space Grotesk", sans-serif;
+	font-family: var(--demo-font);
 	font-weight: 400;
 	line-height: 1.5;
 	min-height: 100vh;
@@ -63,7 +68,7 @@ body {
 	align-items: center;
 	justify-content: space-between;
 	padding-block: clamp(20px, 4vw, 32px) clamp(32px, 6vw, 48px);
-	font-family: "Space Mono", monospace;
+	font-family: var(--demo-font);
 	text-transform: uppercase;
 	letter-spacing: 0.12em;
 	font-size: clamp(11px, 1.5vw, 13px);
@@ -138,7 +143,7 @@ body {
 }
 
 .tagline p {
-	font-family: "Space Grotesk", sans-serif;
+	font-family: var(--demo-font);
 	font-size: clamp(18px, 4vw, 28px);
 	font-weight: 500;
 	line-height: 1.3;
@@ -173,7 +178,7 @@ body {
 }
 
 .showcase__title {
-	font-family: "Space Mono", monospace;
+	font-family: var(--demo-font);
 	font-size: 12px;
 	font-weight: 400;
 	text-transform: uppercase;
@@ -196,7 +201,7 @@ body {
 
 .showcase__label {
 	display: block;
-	font-family: "Space Mono", monospace;
+	font-family: var(--demo-font);
 	font-size: 11px;
 	text-transform: uppercase;
 	letter-spacing: 0.15em;
@@ -206,7 +211,7 @@ body {
 
 /* ドロワーのヒントテキスト */
 .showcase__hint {
-	font-family: "Space Mono", monospace;
+	font-family: var(--demo-font);
 	font-size: 12px;
 	color: #555555;
 	letter-spacing: 0.05em;
@@ -232,7 +237,7 @@ kbd {
 
 /* コードキャプション */
 .showcase__code-caption {
-	font-family: "Space Grotesk", sans-serif;
+	font-family: var(--demo-font);
 	font-size: 14px;
 	font-weight: 500;
 	color: #aaaaaa;
@@ -271,7 +276,7 @@ kbd {
 }
 
 .usage__title {
-	font-family: "Space Mono", monospace;
+	font-family: var(--demo-font);
 	font-size: 12px;
 	font-weight: 400;
 	text-transform: uppercase;
@@ -286,7 +291,7 @@ kbd {
 
 .usage__label {
 	display: block;
-	font-family: "Space Mono", monospace;
+	font-family: var(--demo-font);
 	font-size: 11px;
 	text-transform: uppercase;
 	letter-spacing: 0.15em;
@@ -317,7 +322,7 @@ kbd {
 }
 
 .dock-cta p {
-	font-family: "Space Grotesk", sans-serif;
+	font-family: var(--demo-font);
 	font-size: clamp(14px, 2vw, 16px);
 	color: #888888;
 	margin-bottom: 16px;
@@ -325,7 +330,7 @@ kbd {
 
 .dock-cta a {
 	display: inline-block;
-	font-family: "Space Mono", monospace;
+	font-family: var(--demo-font);
 	font-size: 13px;
 	color: #faf9f6;
 	text-decoration: none;
@@ -351,7 +356,7 @@ kbd {
 	gap: 12px;
 	padding-block: clamp(32px, 6vw, 48px) clamp(40px, 8vw, 64px);
 	border-top: 1px solid #222222;
-	font-family: "Space Mono", monospace;
+	font-family: var(--demo-font);
 	font-size: 12px;
 	text-transform: uppercase;
 	letter-spacing: 0.15em;

--- a/demo/style.css
+++ b/demo/style.css
@@ -1,6 +1,3 @@
-/* === tileui デモページ — Nothing design スタイル === */
-
-/* フォント切り替え: 使いたい方のコメントを外す */
 :root {
 	--demo-font: "Silkscreen", cursive;
 }
@@ -25,12 +22,10 @@
 	--tileui-font-family: "Outfit", sans-serif;
 }
 
-/* ダークモード: スクロールバー等もダークにする */
 html {
 	color-scheme: dark;
 }
 
-/* リセットとベース */
 *,
 *::before,
 *::after {
@@ -50,7 +45,6 @@ body {
 	-moz-osx-font-smoothing: grayscale;
 }
 
-/* 最大幅コンテナ — fluid spacing で余白を段階的に変化 */
 .header,
 .main,
 .tagline,
@@ -62,7 +56,6 @@ body {
 	padding-inline: clamp(16px, 4vw, 24px);
 }
 
-/* ヘッダー — fluid spacing */
 .header {
 	display: flex;
 	align-items: center;
@@ -74,7 +67,6 @@ body {
 	font-size: clamp(11px, 1.5vw, 13px);
 }
 
-/* ヘッダーロゴ — fluid typography */
 .header__logo {
 	font-size: clamp(14px, 2vw, 16px);
 	font-weight: 400;
@@ -101,7 +93,6 @@ body {
 	opacity: 0.7;
 }
 
-/* メインエリア: グリッドレイアウト — fluid spacing */
 .main {
 	display: grid;
 	grid-template-columns: 1fr auto;
@@ -110,7 +101,7 @@ body {
 	padding-bottom: 64px;
 }
 
-/* キャンバスエリア — overflow: hidden で p5.js キャンバスのはみ出しを防止 */
+/* p5.js キャンバスがコンテナからはみ出すため overflow: hidden で抑制 */
 .canvas-area {
 	aspect-ratio: 1 / 1;
 	background: #000000;
@@ -119,12 +110,10 @@ body {
 	overflow: hidden;
 }
 
-/* パネルのタイトル背景もページと統一 */
 .tileui-title {
 	background: transparent;
 }
 
-/* GUI パネルエリア — 白系の細い border でコミカルに */
 .gui-area {
 	border: 1px solid rgba(250, 249, 246, 0.15);
 	border-radius: 8px;
@@ -132,12 +121,10 @@ body {
 	width: fit-content;
 }
 
-/* デスクトップでは Controls パネルを 2 列に制限 */
 .gui-area .tileui-panel {
 	grid-template-columns: repeat(2, var(--tileui-tile-size));
 }
 
-/* タグライン — fluid typography & spacing */
 .tagline {
 	padding-block: clamp(32px, 6vw, 48px);
 }
@@ -150,7 +137,6 @@ body {
 	max-width: 640px;
 }
 
-/* インストールコマンド — fluid typography & spacing */
 .install {
 	padding-bottom: clamp(40px, 8vw, 64px);
 }
@@ -172,7 +158,6 @@ body {
 	opacity: 0.8;
 }
 
-/* ショーケース — Nothing design */
 .showcase {
 	padding-bottom: clamp(40px, 8vw, 64px);
 }
@@ -191,7 +176,6 @@ body {
 	margin-bottom: clamp(32px, 6vw, 48px);
 }
 
-/* ショーケース内のパネルラッパーに gui-area と同じ枠を適用 */
 .showcase__item > div {
 	border: 1px solid rgba(250, 249, 246, 0.15);
 	border-radius: 8px;
@@ -209,7 +193,6 @@ body {
 	margin-bottom: 12px;
 }
 
-/* ドロワーのヒントテキスト */
 .showcase__hint {
 	font-family: var(--demo-font);
 	font-size: 12px;
@@ -217,7 +200,7 @@ body {
 	letter-spacing: 0.05em;
 }
 
-/* コードブロックのテキスト色を固定（ドロワーのカラーピッカーに影響されない） */
+/* ドロワーのカラーピッカーが祖先の color を変えるため、コード要素は固定値で上書き */
 code,
 pre,
 kbd {
@@ -235,7 +218,6 @@ kbd {
 	color: #faf9f6;
 }
 
-/* コードキャプション */
 .showcase__code-caption {
 	font-family: var(--demo-font);
 	font-size: 14px;
@@ -245,7 +227,6 @@ kbd {
 	margin-bottom: 4px;
 }
 
-/* ドック機能のコード例 */
 .showcase__code {
 	margin-top: 16px;
 	font-family: "Space Mono", monospace;
@@ -260,14 +241,12 @@ kbd {
 	max-width: 480px;
 }
 
-/* ドロワーパネルのスタイルオーバーライド（デモ用） */
 .tileui-drawer {
 	background: #000000;
 	border-left: 1px solid rgba(250, 249, 246, 0.15);
 	padding: 4px;
 }
 
-/* 使い方セクション */
 .usage {
 	max-width: 1200px;
 	margin-inline: auto;
@@ -312,7 +291,6 @@ kbd {
 	max-width: 640px;
 }
 
-/* ドックデモへの誘導セクション */
 .dock-cta {
 	max-width: 1200px;
 	margin-inline: auto;
@@ -349,7 +327,6 @@ kbd {
 	border-color: #666666;
 }
 
-/* フッター — fluid spacing */
 .footer {
 	display: flex;
 	align-items: center;
@@ -367,19 +344,16 @@ kbd {
 	color: #333333;
 }
 
-/* レスポンシブ: 1024px 未満で縦積みレイアウト */
 @media (max-width: 1023px) {
 	.main {
 		grid-template-columns: 1fr;
 	}
 
-	/* タブレット以下ではキャンバスを幅いっぱいに広げる */
 	.canvas-area {
 		max-width: none;
 		margin-inline: auto;
 	}
 
-	/* パネルを画面幅に広げ、列数を自動調整して中央寄せ */
 	.gui-area {
 		min-width: unset;
 		width: 100%;
@@ -391,7 +365,6 @@ kbd {
 		justify-content: center;
 	}
 
-	/* ショーケースのパネルも中央寄せ、はみ出す場合はスクロール */
 	.showcase__item > div {
 		width: fit-content;
 		max-width: 100%;
@@ -400,7 +373,6 @@ kbd {
 	}
 }
 
-/* タブレット: 768px 未満 */
 @media (max-width: 767px) {
 	.header__nav {
 		gap: 16px;
@@ -412,7 +384,6 @@ kbd {
 	}
 }
 
-/* モバイル小: 480px 未満 */
 @media (max-width: 479px) {
 	.header {
 		flex-direction: column;


### PR DESCRIPTION
## 概要
- デモページのフォントを Space Grotesk / Space Mono から Outfit / Silkscreen に変更
- セレクタ名から自明なコメントを削除

## 変更内容
- CSS 変数 `--demo-font` を `:root` に導入し、フォント切り替えを 1 箇所に集約
- tileui パネルのフォントは Outfit 固定（`--tileui-font-family`）
- コード要素（`.install__command`, `.showcase__code`, `.usage__code`, `kbd`）は Space Mono を維持
- Google Fonts の読み込みを Outfit + Silkscreen + Space Mono に変更
- dock.html の説明文を英語に変更
- 非自明な補足のみ残し、53 行のコメントを削減

## テスト計画
- `npm run dev` でデモページを表示し、フォントが反映されていることを確認
- dock.html でも同様に確認