### PR TITLE
feat(demo): デモページを英語デフォルト化し EN/JA 切り替え機能を追加

### DIFF
--- a/demo/dock.html
+++ b/demo/dock.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="ja" data-theme="dark">
+<html lang="en" data-lang="en" data-theme="dark">
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -18,12 +18,15 @@
 
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;500&family=Silkscreen:wght@400;700&family=Space+Mono&display=swap" rel="stylesheet" />
+  <link href="https://fonts.googleapis.com/css2?family=DotGothic16&family=Outfit:wght@400;500&family=Silkscreen:wght@400;700&family=Space+Mono&display=swap" rel="stylesheet" />
 
   <style>
     :root {
-      --demo-font: "Silkscreen", cursive;
+      --demo-font: "Silkscreen", "DotGothic16", cursive;
     }
+
+    [data-lang="en"] [lang="ja"] { display: none; }
+    [data-lang="ja"] [lang="en"] { display: none; }
 
     *, *::before, *::after {
       box-sizing: border-box;
@@ -155,25 +158,57 @@
     .dock-center__direction-value {
       color: #b38f59;
     }
+
+    .lang-toggle {
+      display: inline-flex;
+      gap: 4px;
+    }
+
+    .lang-toggle__btn {
+      font-family: var(--demo-font);
+      font-size: 11px;
+      letter-spacing: 0.1em;
+      color: #555555;
+      background: none;
+      border: 1px solid transparent;
+      border-radius: 3px;
+      padding: 2px 8px;
+      cursor: pointer;
+      transition: color 0.15s, border-color 0.15s;
+    }
+
+    .lang-toggle__btn:hover {
+      color: #faf9f6;
+    }
+
+    .lang-toggle__btn--active {
+      color: #faf9f6;
+      border-color: #444444;
+    }
   </style>
 </head>
 <body>
   <header class="dock-header">
     <span class="dock-header__logo">TILEUI</span>
-    <a class="dock-header__link" href="./index.html">&larr; Main Demo</a>
+    <nav style="display: flex; align-items: center; gap: 16px;">
+      <a class="dock-header__link" href="./index.html"><span lang="en">&larr; Main Demo</span><span lang="ja">&larr; メインデモ</span></a>
+      <span class="lang-toggle">
+        <button class="lang-toggle__btn" type="button" data-value="en">EN</button>
+        <button class="lang-toggle__btn" type="button" data-value="ja">JA</button>
+      </span>
+    </nav>
   </header>
 
   <div class="dock-center">
-    <h1 class="dock-center__title">Dock Demo</h1>
+    <h1 class="dock-center__title"><span lang="en">Dock Demo</span><span lang="ja">ドックデモ</span></h1>
     <p class="dock-center__desc">
-      A demo of TileUI's drawer (Dock) mode.<br />
-      Use the buttons in the panel to switch dock direction.
+      <span lang="en">A demo of TileUI's drawer (Dock) mode.<br />Use the buttons in the panel to switch dock direction.</span><span lang="ja">TileUI のドロワー（ドック）モードのデモ。<br />パネル内のボタンでドック方向を切り替えられます。</span>
     </p>
     <p class="dock-center__hint">
-      Press <kbd>G</kbd> to toggle drawer
+      <span lang="en">Press <kbd>G</kbd> to toggle drawer</span><span lang="ja"><kbd>G</kbd> キーでドロワーを切替</span>
     </p>
     <p class="dock-center__direction">
-      Current: <span class="dock-center__direction-value" id="direction-label">RIGHT</span>
+      <span lang="en">Current:</span><span lang="ja">現在:</span> <span class="dock-center__direction-value" id="direction-label">RIGHT</span>
     </p>
   </div>
 

--- a/demo/dock.html
+++ b/demo/dock.html
@@ -7,7 +7,7 @@
   <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
   <meta http-equiv="Pragma" content="no-cache">
   <meta http-equiv="Expires" content="0">
-  <title>TileUI - Dock Demo</title>
+  <title>TileUI - Demo</title>
 
   <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png" />
   <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16.png" />
@@ -200,7 +200,7 @@
   </header>
 
   <div class="dock-center">
-    <h1 class="dock-center__title"><span lang="en">Dock Demo</span><span lang="ja">ドックデモ</span></h1>
+    <h1 class="dock-center__title"><span lang="en">Demo</span><span lang="ja">Demo</span></h1>
     <p class="dock-center__desc">
       <span lang="en">A demo of TileUI's drawer (Dock) mode.<br />Use the buttons in the panel to switch dock direction.</span><span lang="ja">TileUI のドロワー（ドック）モードのデモ。<br />パネル内のボタンでドック方向を切り替えられます。</span>
     </p>

--- a/demo/dock.ts
+++ b/demo/dock.ts
@@ -2,6 +2,12 @@
 
 import type { DockPosition } from '../src';
 import TileUI from '../src';
+import { initI18n } from './i18n';
+
+initI18n({
+	en: 'TileUI - Dock Demo',
+	ja: 'TileUI - ドックデモ',
+});
 
 /** ドロワーのアクセントカラー（ゴールド系） */
 const ACCENT = '#b38f59';

--- a/demo/dock.ts
+++ b/demo/dock.ts
@@ -5,8 +5,8 @@ import TileUI from '../src';
 import { initI18n } from './i18n';
 
 initI18n({
-	en: 'TileUI - Dock Demo',
-	ja: 'TileUI - ドックデモ',
+	en: 'TileUI - Demo',
+	ja: 'TileUI - Demo',
 });
 
 /** ドロワーのアクセントカラー（ゴールド系） */

--- a/demo/i18n.ts
+++ b/demo/i18n.ts
@@ -1,0 +1,74 @@
+// デモページの言語切り替え（EN/JA トグル）
+
+type Lang = 'en' | 'ja';
+
+const STORAGE_KEY = 'tileui-demo-lang';
+
+/** ページごとのタイトル定義 */
+interface PageTitles {
+	en: string;
+	ja: string;
+}
+
+/** localStorage から保存済みの言語設定を復元する */
+function getSavedLang(): Lang | null {
+	try {
+		const saved = localStorage.getItem(STORAGE_KEY);
+		if (saved === 'en' || saved === 'ja') {
+			return saved;
+		}
+	} catch {
+		// localStorage が使えない環境では無視する
+	}
+	return null;
+}
+
+/** 言語設定を localStorage に保存する */
+function saveLang(lang: Lang): void {
+	try {
+		localStorage.setItem(STORAGE_KEY, lang);
+	} catch {
+		// localStorage が使えない環境では無視する
+	}
+}
+
+/** data-lang 属性と document.title を切り替える */
+function applyLang(lang: Lang, titles: PageTitles): void {
+	document.documentElement.setAttribute('data-lang', lang);
+	document.title = titles[lang];
+}
+
+/** トグルボタンのアクティブ状態を更新する */
+function updateToggleButtons(lang: Lang): void {
+	const enBtn = document.querySelector<HTMLButtonElement>('.lang-toggle__btn[data-value="en"]');
+	const jaBtn = document.querySelector<HTMLButtonElement>('.lang-toggle__btn[data-value="ja"]');
+	if (enBtn) {
+		enBtn.classList.toggle('lang-toggle__btn--active', lang === 'en');
+	}
+	if (jaBtn) {
+		jaBtn.classList.toggle('lang-toggle__btn--active', lang === 'ja');
+	}
+}
+
+/** i18n を初期化する。ページ読み込み時に呼び出す */
+export function initI18n(titles: PageTitles): void {
+	const saved = getSavedLang();
+	const lang: Lang = saved ?? 'en';
+
+	applyLang(lang, titles);
+	updateToggleButtons(lang);
+
+	document.addEventListener('click', (e) => {
+		const btn = (e.target as HTMLElement).closest<HTMLButtonElement>('.lang-toggle__btn');
+		if (!btn) {
+			return;
+		}
+		const value = btn.dataset.value;
+		if (value !== 'en' && value !== 'ja') {
+			return;
+		}
+		applyLang(value, titles);
+		updateToggleButtons(value);
+		saveLang(value);
+	});
+}

--- a/demo/index.html
+++ b/demo/index.html
@@ -35,7 +35,7 @@
     <nav class="header__nav">
       <span class="header__version" id="version"></span>
       <a class="header__link" href="https://www.npmjs.com/package/@yuske-nakajima/tileui" target="_blank" rel="noopener noreferrer">npm</a>
-      <a class="header__link" href="./dock.html"><span lang="en">Dock Demo</span><span lang="ja">ドックデモ</span></a>
+      <a class="header__link" href="./dock.html"><span lang="en">Demo</span><span lang="ja">Demo</span></a>
       <a class="header__link" href="https://github.com/yuske-nakajima/tileui" target="_blank" rel="noopener noreferrer">GitHub &#8599;</a>
       <span class="lang-toggle">
         <button class="lang-toggle__btn" type="button" data-value="en">EN</button>
@@ -122,8 +122,8 @@ gui.open();</code></pre>
   </section>
 
   <section class="dock-cta">
-    <p><span lang="en">Try the interactive dock demo with all four directions</span><span lang="ja">4 方向のインタラクティブドックデモを試す</span></p>
-    <a href="./dock.html"><span lang="en">Go to Dock Demo &rarr;</span><span lang="ja">ドックデモへ &rarr;</span></a>
+    <p><span lang="en">Try the interactive dock demo with all four directions</span><span lang="ja">4 方向のインタラクティブDemoを試す</span></p>
+    <a href="./dock.html"><span lang="en">Go to Demo &rarr;</span><span lang="ja">Demoへ &rarr;</span></a>
   </section>
 
   <footer class="footer">

--- a/demo/index.html
+++ b/demo/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="ja" data-theme="dark">
+<html lang="en" data-lang="en" data-theme="dark">
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -24,7 +24,7 @@
 
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;500&family=Silkscreen:wght@400;700&family=Space+Mono&display=swap" rel="stylesheet" />
+  <link href="https://fonts.googleapis.com/css2?family=DotGothic16&family=Outfit:wght@400;500&family=Silkscreen:wght@400;700&family=Space+Mono&display=swap" rel="stylesheet" />
 
   <link rel="stylesheet" href="./style.css" />
   <script src="https://cdn.jsdelivr.net/npm/p5@1/lib/p5.min.js"></script>
@@ -35,8 +35,12 @@
     <nav class="header__nav">
       <span class="header__version" id="version"></span>
       <a class="header__link" href="https://www.npmjs.com/package/@yuske-nakajima/tileui" target="_blank" rel="noopener noreferrer">npm</a>
-      <a class="header__link" href="./dock.html">Dock Demo</a>
+      <a class="header__link" href="./dock.html"><span lang="en">Dock Demo</span><span lang="ja">ドックデモ</span></a>
       <a class="header__link" href="https://github.com/yuske-nakajima/tileui" target="_blank" rel="noopener noreferrer">GitHub &#8599;</a>
+      <span class="lang-toggle">
+        <button class="lang-toggle__btn" type="button" data-value="en">EN</button>
+        <button class="lang-toggle__btn" type="button" data-value="ja">JA</button>
+      </span>
     </nav>
   </header>
 
@@ -46,7 +50,7 @@
   </main>
 
   <section class="tagline">
-    <p>A grid-tile GUI panel with SVG rotary knobs for creative coding</p>
+    <p><span lang="en">A grid-tile GUI panel with SVG rotary knobs for creative coding</span><span lang="ja">クリエイティブコーディングのための SVG ロータリーノブ付きグリッドタイル GUI パネル</span></p>
   </section>
 
   <section class="install">
@@ -54,9 +58,9 @@
   </section>
 
   <section class="usage">
-    <h2 class="usage__title">USAGE</h2>
+    <h2 class="usage__title"><span lang="en">USAGE</span><span lang="ja">使い方</span></h2>
     <div class="usage__item">
-      <span class="usage__label">ESM (recommended)</span>
+      <span class="usage__label"><span lang="en">ESM (recommended)</span><span lang="ja">ESM（推奨）</span></span>
       <pre class="usage__code"><code>import TileUI from '@yuske-nakajima/tileui';</code></pre>
     </div>
     <div class="usage__item">
@@ -75,32 +79,32 @@
   </section>
 
   <section class="showcase">
-    <h2 class="showcase__title">EXAMPLES</h2>
+    <h2 class="showcase__title"><span lang="en">EXAMPLES</span><span lang="ja">作例</span></h2>
 
     <div class="showcase__item">
-      <span class="showcase__label">2 COLUMNS</span>
+      <span class="showcase__label"><span lang="en">2 COLUMNS</span><span lang="ja">2 列</span></span>
       <div id="showcase-2col"></div>
     </div>
 
     <div class="showcase__item">
-      <span class="showcase__label">3 COLUMNS</span>
+      <span class="showcase__label"><span lang="en">3 COLUMNS</span><span lang="ja">3 列</span></span>
       <div id="showcase-3col"></div>
     </div>
 
     <div class="showcase__item">
-      <span class="showcase__label">4 COLUMNS</span>
+      <span class="showcase__label"><span lang="en">4 COLUMNS</span><span lang="ja">4 列</span></span>
       <div id="showcase-4col"></div>
     </div>
 
     <div class="showcase__item">
-      <span class="showcase__label">CUSTOM STYLES</span>
+      <span class="showcase__label"><span lang="en">CUSTOM STYLES</span><span lang="ja">カスタムスタイル</span></span>
       <div id="showcase-styled"></div>
     </div>
 
     <div class="showcase__item">
-      <span class="showcase__label">DOCK (RIGHT DRAWER)</span>
-      <p class="showcase__hint">Press <kbd>G</kbd> to toggle or use the edge button</p>
-      <h3 class="showcase__code-caption">Dock Drawer — Slide-in panel from any edge</h3>
+      <span class="showcase__label"><span lang="en">DOCK (RIGHT DRAWER)</span><span lang="ja">ドック（右ドロワー）</span></span>
+      <p class="showcase__hint"><span lang="en">Press <kbd>G</kbd> to toggle or use the edge button</span><span lang="ja"><kbd>G</kbd> キーで切替、またはエッジボタンを使用</span></p>
+      <h3 class="showcase__code-caption"><span lang="en">Dock Drawer — Slide-in panel from any edge</span><span lang="ja">ドックドロワー — 任意の辺からスライドインするパネル</span></h3>
       <pre class="showcase__code"><code>const gui = new TileUI({
   dock: 'right',
   collapsible: true,
@@ -118,8 +122,8 @@ gui.open();</code></pre>
   </section>
 
   <section class="dock-cta">
-    <p>Try the interactive dock demo with all four directions</p>
-    <a href="./dock.html">Go to Dock Demo &rarr;</a>
+    <p><span lang="en">Try the interactive dock demo with all four directions</span><span lang="ja">4 方向のインタラクティブドックデモを試す</span></p>
+    <a href="./dock.html"><span lang="en">Go to Dock Demo &rarr;</span><span lang="ja">ドックデモへ &rarr;</span></a>
   </section>
 
   <footer class="footer">

--- a/demo/main.ts
+++ b/demo/main.ts
@@ -3,7 +3,13 @@
 declare const __VERSION__: string;
 
 import TileUI from '../src';
+import { initI18n } from './i18n';
 import { artParams, initSketch, resizeSketch } from './sketch';
+
+initI18n({
+	en: 'TileUI - A Grid-Tile GUI Panel for Creative Coding',
+	ja: 'TileUI - クリエイティブコーディングのためのグリッドタイル GUI パネル',
+});
 
 /** ID から要素を取得し、見つからなければエラーを投げる */
 function getElement(id: string): HTMLElement {

--- a/demo/style.css
+++ b/demo/style.css
@@ -1,5 +1,12 @@
 :root {
-	--demo-font: "Silkscreen", cursive;
+	--demo-font: "Silkscreen", "DotGothic16", cursive;
+}
+
+[data-lang="en"] [lang="ja"] {
+	display: none;
+}
+[data-lang="ja"] [lang="en"] {
+	display: none;
 }
 
 /*
@@ -403,4 +410,33 @@ kbd {
 	.footer {
 		font-size: 10px;
 	}
+}
+
+.lang-toggle {
+	display: inline-flex;
+	gap: 4px;
+}
+
+.lang-toggle__btn {
+	font-family: var(--demo-font);
+	font-size: 11px;
+	letter-spacing: 0.1em;
+	color: #555555;
+	background: none;
+	border: 1px solid transparent;
+	border-radius: 3px;
+	padding: 2px 8px;
+	cursor: pointer;
+	transition:
+		color 0.15s,
+		border-color 0.15s;
+}
+
+.lang-toggle__btn:hover {
+	color: #faf9f6;
+}
+
+.lang-toggle__btn--active {
+	color: #faf9f6;
+	border-color: #444444;
 }


### PR DESCRIPTION
## 概要

- デモページ（`index.html` / `dock.html`）の表示言語を英語デフォルトに変更
- EN/JA トグルボタンで日本語表示に切り替え可能
- 選択した言語は `localStorage` に保存し、ページ再訪時に復元

closes #109

## 変更内容

- `demo/i18n.ts` を新規作成: `data-lang` 属性切り替え・`document.title` 切り替え・`localStorage` 永続化・トグルボタン状態管理
- `demo/index.html` / `demo/dock.html`: `data-lang="en"` をデフォルトに設定し、テキストを `<span lang="en">` / `<span lang="ja">` でラップ
- `demo/main.ts` / `demo/dock.ts`: `initI18n()` を呼び出してタイトル切り替えを登録
- `demo/style.css`: `[data-lang]` による表示/非表示ルール、`.lang-toggle` / `.lang-toggle__btn` スタイルを追加
- Silkscreen フォントの日本語フォールバックとして DotGothic16 を追加

### 軽微な問題（対応任意）

`dock.html` 内の `<style>` ブロックに `.lang-toggle` / `.lang-toggle__btn` スタイルが重複定義されている（`style.css` 側にも同一定義あり）。機能上の問題なし。

## テスト計画

- `npm run test:e2e` でリグレッションなし（デモページ変更のため必須）
- EN/JA トグルで表示言語が切り替わることを手動確認
- ページ再読み込み後、前回選択した言語が復元されることを手動確認
